### PR TITLE
Fix errors caused by items that are not cached

### DIFF
--- a/Neuron-Buttons.lua
+++ b/Neuron-Buttons.lua
@@ -888,7 +888,11 @@ function NeuronButton:MACRO_SetItemIcon(button, item)
 		end
 
 	else
-		texture = GetItemIcon("item:"..ItemCache[item]..":0:0:0:0:0:0:0")
+		if (ItemCache[item]) then
+			texture = GetItemIcon("item:"..ItemCache[item]..":0:0:0:0:0:0:0")
+		else
+			_,_,_,_,_,_,_,_,_,texture = GetItemInfo(item)
+		end
 
 		if (texture) then
 			button.iconframeicon:SetTexture(texture)


### PR DESCRIPTION
Items that are used in a button's macro via their slot id (i.e. "/use 15" to use cloak) are never cached in the ItemCache table and will therefore cause a concatenation error every few frames. This edit simply performs a nil check and gets icon info if it is not cached.