### PR TITLE
Fix for multiple zone abilities used for covenant skills next week

### DIFF
--- a/Neuron-GUI.lua
+++ b/Neuron-GUI.lua
@@ -891,11 +891,10 @@ function NeuronGUI:countOnMouseWheel(delta)
 	local bar = Neuron.CurrentBar
 
 	if (bar) then
-
 		if (delta > 0) then
-			Neuron.bar:AddObjectsToBar()
+			bar:AddObjectsToBar()
 		else
-			Neuron.bar:RemoveObjectsFromBar()
+			bar:RemoveObjectsFromBar()
 		end
 	end
 end

--- a/Neuron-Startup.lua
+++ b/Neuron-Startup.lua
@@ -51,7 +51,7 @@ function Neuron:RegisterBars()
 
 	if not Neuron.isWoWClassic then
 		--Neuron Zone Ability Bar
-		Neuron:RegisterBarClass("ZoneAbilityBar", "ZoneAbilityBar", L["Zone Action Bar"], "Zone Action Button", DB.ZoneAbilityBar, Neuron.ZONEABILITYBTN, 1, true)
+		Neuron:RegisterBarClass("ZoneAbilityBar", "ZoneAbilityBar", L["Zone Action Bar"], "Zone Action Button", DB.ZoneAbilityBar, Neuron.ZONEABILITYBTN, 5, true)
 
 		--Neuron Extra Bar
 		Neuron:RegisterBarClass("ExtraBar", "ExtraBar", L["Extra Action Bar"], "Extra Action Button", DB.ExtraBar, Neuron.EXTRABTN,1, true)

--- a/Objects/ZONEABILITYBTN.lua
+++ b/Objects/ZONEABILITYBTN.lua
@@ -33,6 +33,7 @@ Neuron.ZONEABILITYBTN = ZONEABILITYBTN
 function ZONEABILITYBTN.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
 	local newButton = Neuron.BUTTON.new(bar, buttonID, ZONEABILITYBTN, "ZoneAbilityBar", "ZoneActionButton", "NeuronActionButtonTemplate")
+	newButton.AbiltyIndex = buttonID
 
 	if defaults then
 		newButton:SetDefaults(defaults)
@@ -83,12 +84,14 @@ function ZONEABILITYBTN:UpdateData()
 
 	table.sort(zoneAbilityTable, function(a, b) return a.uiPriority < b.uiPriority end);
 
-	---TODO: We will want to revisit this as it seems like now we can have multiple zone abilities at once now. This is just a patch
-	if #zoneAbilityTable > 0 then
-		self.spellID = zoneAbilityTable[1].spellID
-		self.textureKit = zoneAbilityTable[1].textureKit
+	local ability = zoneAbilityTable[self.AbiltyIndex]
+	if ability then
+		self.spellID = ability.spellID
+		self.textureKit = ability.textureKit
+	else
+		self.spellID = nil
+		self.textureKit = nil
 	end
-
 
 	if self.spellID then
 		self.spell = GetSpellInfo(self.spellID);

--- a/Objects/ZONEABILITYBTN.lua
+++ b/Objects/ZONEABILITYBTN.lua
@@ -81,6 +81,7 @@ end
 function ZONEABILITYBTN:UpdateData()
 	--get table with zone ability info. The table has 5 values, "zoneAbilityID", "uiPriority", "spellID", "textureKit", and "tutorialText"
 	local zoneAbilityTable = C_ZoneAbility.GetActiveAbilities()
+	self.disableFlair = #zoneAbilityTable > 1
 
 	table.sort(zoneAbilityTable, function(a, b) return a.uiPriority < b.uiPriority end);
 
@@ -136,7 +137,7 @@ function ZONEABILITYBTN:UpdateIcon()
 		self.elements.Flair:SetTexture(texture);
 	end
 
-	if self.bar.data.showBorderStyle then
+	if not self.disableFlair and self.bar.data.showBorderStyle then
 		self.elements.Flair:Show() --this actually show/hide the fancy button theme surrounding the bar. If you wanted to do a toggle for the style, it should be here.
 	else
 		self.elements.Flair:Hide()


### PR DESCRIPTION
Add support for multiple zone abilities buttons and disable there flair that's the wrong layer and might need a parent UI object for now until they can be fixed.

The built-in zone ability bar with multiple buttons looks like this:
![builtin](https://user-images.githubusercontent.com/241431/99553337-ef90dd80-29b5-11eb-8eb8-fdb7013eda11.png)

without disabling flairs Neuron looks like this on beta when i added support for multiple abilities :
![badflair](https://user-images.githubusercontent.com/241431/99553536-29fa7a80-29b6-11eb-93c0-b87e163eea06.jpg)

with flairs disabled you can at least see the icon:
![noflair](https://user-images.githubusercontent.com/241431/99554615-4ea32200-29b7-11eb-9885-8aa78288091f.jpg)

