### PR TITLE
Update BUTTON.lua

### DIFF
--- a/Objects/BUTTON.lua
+++ b/Objects/BUTTON.lua
@@ -553,7 +553,7 @@ function BUTTON:SetSkinned(flyout)
 end
 
 function BUTTON:GetSkinned()
-	if self.__MSQ_NormalTexture then
+	if self.__MSQ_NormalSkin then
 		local Skin = self.__MSQ_NormalSkin
 
 		if Skin then


### PR DESCRIPTION
fixes #315


### Initially intended as a comment on #315

I also had this issue with the "Dream" skin. Seeing you seem to have your hands full (thank you @brittyazel for an amazing addon I couldn't live without), I did some digging. Despite lacking any prior experience with Masque, I think I have found the culprit.

[`BUTTON:GetSkinned()`](https://github.com/brittyazel/Neuron/blob/82cd71f072187cbc5c3e4adb8e9dcde64593e7e8/Objects/BUTTON.lua#L555), more specifically [`if self.__MSQ_NormalTexture then`](https://github.com/brittyazel/Neuron/blob/82cd71f072187cbc5c3e4adb8e9dcde64593e7e8/Objects/BUTTON.lua#L556).

It seems to me as if `__MSQ_NormalTexture` simply isn't a thing, and that the correct key name would be `__MSQ_Normal` for the texture. However, seeing we don't actually reference self.__MSQ_Normal~~Texture~~ anywhere else in the function, I changed it to

`if self.__MSQ_NormalSkin then` instead. 

This appears to have fixed the issue for me. Hopefully this turns out to be a fix for everyone else as well.