### PR TITLE
Fix item tooltips flashing for an instant in BCC

### DIFF
--- a/Objects/BUTTON.lua
+++ b/Objects/BUTTON.lua
@@ -996,7 +996,9 @@ function BUTTON:UpdateItemTooltip()
 
 	if name and link then
 		if self.UberTooltips then
-			GameTooltip:SetHyperlink(link)
+			if select(2, GameTooltip:GetItem()) ~= link then
+				GameTooltip:SetHyperlink(link)
+			end
 		else
 			GameTooltip:SetText(name, 1, 1, 1)
 		end


### PR DESCRIPTION
Calling `GameTooltip:SetHyperlink` twice with the same link causes it to hide itself, for reasons unknown.

Compare first, do nothing if it's already showing this.

I wasn't able to easily test the fallthrough case where we're passing an unknown item fragment in -- there might still be a flash when the tooltip would otherwise read "Retrieving Item Information...".  I'm not sure what `:GetItem()` would return in that case to compare though, we'd need more specific tracking of when we show/hide the tooltip and what we asked it to display.