### PR TITLE
Rename all objects from all-caps to pascal case for consistency

### DIFF
--- a/GUI/BarEditTab.lua
+++ b/GUI/BarEditTab.lua
@@ -49,7 +49,7 @@ function NeuronGUI:BarEditPanel(tabFrame)
 	barListDropdown:SetLabel("Switch selected bar:")
 	barListDropdown:SetText(Neuron.currentBar:GetBarName() or "")
 	barListDropdown:SetList(barList) --assign the bar type table to the dropdown menu
-	barListDropdown:SetCallback("OnValueChanged", function(self, callBackType, key) Neuron.BAR.ChangeSelectedBar(key); NeuronGUI:RefreshEditor() end)
+	barListDropdown:SetCallback("OnValueChanged", function(self, callBackType, key) Neuron.Bar.ChangeSelectedBar(key); NeuronGUI:RefreshEditor() end)
 	topRow:AddChild(barListDropdown)
 
 	-------------------------------
@@ -93,7 +93,7 @@ function NeuronGUI:BarEditPanel(tabFrame)
 	newBarButton = AceGUI:Create("Button")
 	newBarButton:SetWidth(120)
 	newBarButton:SetText("Create")
-	newBarButton:SetCallback("OnClick", function() if selectedBarType then Neuron.BAR:CreateNewBar(selectedBarType); NeuronGUI:RefreshEditor() end end)
+	newBarButton:SetCallback("OnClick", function() if selectedBarType then Neuron.Bar:CreateNewBar(selectedBarType); NeuronGUI:RefreshEditor() end end)
 	if selectedBarType then
 		newBarButton:SetDisabled(false)
 	else

--- a/Neuron-Console.lua
+++ b/Neuron-Console.lua
@@ -90,7 +90,7 @@ function Neuron:slashHandler(input)
 
 			if func == "ChangeBar" then --intercept our bar assignment and reassign to the new bar, if it exists
 				local newBar
-				for _,v in pairs(Neuron.BARIndex) do
+				for _,v in pairs(Neuron.BarIndex) do
 					if v.data.name == args[1] then
 						newBar = v
 						break

--- a/Neuron-Startup.lua
+++ b/Neuron-Startup.lua
@@ -20,38 +20,38 @@ end
 function Neuron:RegisterBars()
 
 	--Neuron Action Bar
-	Neuron:RegisterBarClass("ActionBar", "ActionBar", L["Action Bar"], "Action Button", DB.ActionBar, Neuron.ACTIONBUTTON, 250)
+	Neuron:RegisterBarClass("ActionBar", "ActionBar", L["Action Bar"], "Action Button", DB.ActionBar, Neuron.ActionButton, 250)
 
 	--Neuron Bag Bar
-	Neuron:RegisterBarClass("BagBar", "BagBar", L["Bag Bar"], "Bag Button", DB.BagBar, Neuron.BAGBTN, Neuron.NUM_BAG_BUTTONS) --Neuron.NUM_BAG_BUTTONS == 5 for retail and 6 for classic due to the keyring
+	Neuron:RegisterBarClass("BagBar", "BagBar", L["Bag Bar"], "Bag Button", DB.BagBar, Neuron.BagButton, Neuron.NUM_BAG_BUTTONS)
 
 	--Neuron Menu Bar
-	Neuron:RegisterBarClass("MenuBar", "MenuBar", L["Menu Bar"], "Menu Button", DB.MenuBar, Neuron.MENUBTN, 11)
+	Neuron:RegisterBarClass("MenuBar", "MenuBar", L["Menu Bar"], "Menu Button", DB.MenuBar, Neuron.MenuButton, 11)
 
 	--Neuron Pet Bar
-	Neuron:RegisterBarClass("PetBar", "PetBar", L["Pet Bar"], "Pet Button", DB.PetBar, Neuron.PETBTN, 10)
+	Neuron:RegisterBarClass("PetBar", "PetBar", L["Pet Bar"], "Pet Button", DB.PetBar, Neuron.PetButton, 10)
 
 	--Neuron XP Bar
-	Neuron:RegisterBarClass("XPBar", "XPBar", L["XP Bar"], "XP Button", DB.XPBar, Neuron.XPBTN, 10)
+	Neuron:RegisterBarClass("XPBar", "XPBar", L["XP Bar"], "XP Button", DB.XPBar, Neuron.ExpButton, 10)
 
 	--Neuron Rep Bar
-	Neuron:RegisterBarClass("RepBar", "RepBar", L["Rep Bar"], "Rep Button", DB.RepBar, Neuron.REPBTN, 10)
+	Neuron:RegisterBarClass("RepBar", "RepBar", L["Rep Bar"], "Rep Button", DB.RepBar, Neuron.RepButton, 10)
 
 	--Neuron Cast Bar
-	Neuron:RegisterBarClass("CastBar", "CastBar", L["Cast Bar"], "Cast Button", DB.CastBar, Neuron.CASTBTN, 10)
+	Neuron:RegisterBarClass("CastBar", "CastBar", L["Cast Bar"], "Cast Button", DB.CastBar, Neuron.CastButton, 10)
 
 	--Neuron Mirror Bar
-	Neuron:RegisterBarClass("MirrorBar", "MirrorBar", L["Mirror Bar"], "Mirror Button", DB.MirrorBar, Neuron.MIRRORBTN, 10)
+	Neuron:RegisterBarClass("MirrorBar", "MirrorBar", L["Mirror Bar"], "Mirror Button", DB.MirrorBar, Neuron.MirrorButton, 10)
 
 	if Neuron.isWoWRetail then
 		--Neuron Zone Ability Bar
-		Neuron:RegisterBarClass("ZoneAbilityBar", "ZoneAbilityBar", L["Zone Action Bar"], "Zone Action Button", DB.ZoneAbilityBar, Neuron.ZONEABILITYBTN, 5, true)
+		Neuron:RegisterBarClass("ZoneAbilityBar", "ZoneAbilityBar", L["Zone Action Bar"], "Zone Action Button", DB.ZoneAbilityBar, Neuron.ZoneAbilityButton, 5, true)
 
 		--Neuron Extra Bar
-		Neuron:RegisterBarClass("ExtraBar", "ExtraBar", L["Extra Action Bar"], "Extra Action Button", DB.ExtraBar, Neuron.EXTRABTN, 1)
+		Neuron:RegisterBarClass("ExtraBar", "ExtraBar", L["Extra Action Bar"], "Extra Action Button", DB.ExtraBar, Neuron.ExtraButton, 1)
 
 		--Neuron Exit Bar
-		Neuron:RegisterBarClass("ExitBar", "ExitBar", L["Vehicle Exit Bar"], "Vehicle Exit Button", DB.ExitBar, Neuron.EXITBTN, 1)
+		Neuron:RegisterBarClass("ExitBar", "ExitBar", L["Vehicle Exit Bar"], "Vehicle Exit Button", DB.ExitBar, Neuron.ExitButton, 1)
 	end
 
 end
@@ -222,13 +222,13 @@ function Neuron:CreateBarsAndButtons()
 		for barClass, barDefaults in pairs(addonTable.defaultBarOptions) do
 			if Neuron.registeredBarData[barClass] then --only build default bars for registered bars types (Classic doesn't use all the bar types that Retail does)
 				for i, defaults in ipairs(barDefaults) do --create the bar objects
-					local newBar = Neuron.BAR.new(barClass, i) --this calls the bar constructor
+					local newBar = Neuron.Bar.new(barClass, i) --this calls the bar constructor
 
 					--create the default button objects for a given bar with the default values
 					newBar:SetDefaults(defaults)
 
 					for buttonID=1,#defaults.buttons do
-						newBar.objTemplate.new(newBar, buttonID, defaults.buttons[buttonID]) --newBar.objTemplate is something like ACTIONBUTTON or EXTRABTN, we just need to code it agnostic
+						newBar.objTemplate.new(newBar, buttonID, defaults.buttons[buttonID]) --newBar.objTemplate is something like ActionButton or ExtraButton, we just need to code it agnostic
 					end
 				end
 			end
@@ -242,11 +242,11 @@ function Neuron:CreateBarsAndButtons()
 		for barClass, barClassData in pairs (Neuron.registeredBarData) do
 			for id,data in pairs(barClassData.barDB) do
 				if data ~= nil then
-					local newBar = Neuron.BAR.new(barClass, id) --this calls the bar constructor
+					local newBar = Neuron.Bar.new(barClass, id) --this calls the bar constructor
 
 					--create all the saved button objects for a given bar
 					for buttonID=1,#newBar.data.buttons do
-						newBar.objTemplate.new(newBar, buttonID) --newBar.objTemplate is something like ACTIONBUTTON or EXTRABTN, we just need to code it agnostic
+						newBar.objTemplate.new(newBar, buttonID) --newBar.objTemplate is something like ActionButton or ExtraButton, we just need to code it agnostic
 					end
 				end
 			end

--- a/Neuron.lua
+++ b/Neuron.lua
@@ -473,7 +473,7 @@ function Neuron:ToggleBarEditMode(show)
 		--if there is no bar selected, default to the first in the BarList
 		--TODO: This logic may be unintuitive. Should probably be fixed
 		if not Neuron.currentBar then
-			Neuron.BAR.ChangeSelectedBar(Neuron.bars[1])
+			Neuron.Bar.ChangeSelectedBar(Neuron.bars[1])
 		end
 	else
 		Neuron.barEditMode = false
@@ -502,12 +502,12 @@ function Neuron:ToggleButtonEditMode(show)
 					if not Neuron.currentButton then
 						if Neuron.currentBar then
 							if Neuron.currentBar.buttons[1].editFrame then --try to set the selected button to the first button on the selected bar, if it has an edit frame
-								Neuron.BUTTON.ChangeSelectedButton(Neuron.currentBar.buttons[1])
+								Neuron.Button.ChangeSelectedButton(Neuron.currentBar.buttons[1])
 							else
-								Neuron.BUTTON.ChangeSelectedButton(button) --if there's no edit frame, then just default to the selected button to the first bar in the list
+								Neuron.Button.ChangeSelectedButton(button) --if there's no edit frame, then just default to the selected button to the first bar in the list
 							end
 						else
-							Neuron.BUTTON.ChangeSelectedButton(button) --default to the selected button to the first bar in the list
+							Neuron.Button.ChangeSelectedButton(button) --default to the selected button to the first bar in the list
 						end
 					end
 				end

--- a/Neuron.toc
+++ b/Neuron.toc
@@ -29,25 +29,25 @@ Neuron-States.lua
 
 Utilities\DB-Fixer.lua
 
-Objects\BUTTON.lua
-Objects\BUTTON_EditorOverlay.lua
-Objects\BUTTON_KeybindOverlay.lua
-Objects\BAR.lua
-Objects\ACTIONBUTTON.lua
-Objects\ACTIONBUTTON_DragAndDrop.lua
-Objects\ACTIONBUTTON_Flyout.lua
-Objects\BAGBTN.lua
-Objects\EXITBTN.lua
-Objects\EXTRABTN.lua
-Objects\MENUBTN.lua
-Objects\PETBTN.lua
-Objects\ZONEABILITYBTN.lua
-Objects\BAR_SnapTo.lua
-Objects\STATUSBTN.lua
-Objects\XPBTN.lua
-Objects\REPBTN.lua
-Objects\CASTBTN.lua
-Objects\MIRRORBTN.lua
+Objects\Button.lua
+Objects\Button_EditorOverlay.lua
+Objects\Button_KeybindOverlay.lua
+Objects\Bar.lua
+Objects\ActionButton.lua
+Objects\ActionButton_DragAndDrop.lua
+Objects\ActionButton_Flyout.lua
+Objects\BagButton.lua
+Objects\ExitButton.lua
+Objects\ExtraButton.lua
+Objects\MenuButton.lua
+Objects\PetButton.lua
+Objects\ZoneAbilityButton.lua
+Objects\Bar_SnapTo.lua
+Objects\StatusButton.lua
+Objects\ExpButton.lua
+Objects\RepButton.lua
+Objects\CastButton.lua
+Objects\MirrorButton.lua
 
 Neuron-DisableBlizzardUI.lua
 Neuron-Console.lua

--- a/Objects/ActionButton.lua
+++ b/Objects/ActionButton.lua
@@ -6,9 +6,9 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class ACTIONBUTTON : BUTTON @define class ACTIONBUTTON inherits from class BUTTON
-local ACTIONBUTTON = setmetatable({}, {__index = Neuron.BUTTON}) --this is the metatable for our button object
-Neuron.ACTIONBUTTON = ACTIONBUTTON
+---@class ActionButton : Button @define class ActionButton inherits from class Button
+local ActionButton = setmetatable({}, {__index = Neuron.Button}) --this is the metatable for our button object
+Neuron.ActionButton = ActionButton
 
 ---------------------------------------------------------
 -------------------declare globals-----------------------
@@ -47,14 +47,14 @@ local COMMAND_LIST = {
 	["#showtooltip"] = true,
 }
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return ACTIONBUTTON @ A newly created ACTIONBUTTON object
-function ACTIONBUTTON.new(bar, buttonID, defaults)
+---@return ActionButton @ A newly created ActionButton object
+function ActionButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.BUTTON.new(bar, buttonID, ACTIONBUTTON, "ActionBar", "ActionButton", "NeuronActionButtonTemplate")
+	local newButton = Neuron.Button.new(bar, buttonID, ActionButton, "ActionBar", "ActionButton", "NeuronActionButtonTemplate")
 
 	if defaults then
 		newButton:SetDefaults(defaults)
@@ -66,7 +66,7 @@ function ACTIONBUTTON.new(bar, buttonID, defaults)
 	return newButton
 end
 
-function ACTIONBUTTON:InitializeButton()
+function ActionButton:InitializeButton()
 	self:ClearButton(true)
 
 	SecureHandler_OnLoad(self)
@@ -90,10 +90,10 @@ function ACTIONBUTTON:InitializeButton()
 	--this is to allow for the correct releasing of the button when dragging icons off of the bar
 	--we need to hook to the WorldFrame OnReceiveDrag and OnMouseDown so that we can "let go" of the spell when we drag it off the bar
 	if not Neuron:IsHooked(WorldFrame, "OnReceiveDrag") then
-		Neuron:HookScript(WorldFrame, "OnReceiveDrag", function() ACTIONBUTTON:WorldFrame_OnReceiveDrag() end)
+		Neuron:HookScript(WorldFrame, "OnReceiveDrag", function() ActionButton:WorldFrame_OnReceiveDrag() end)
 	end
 	if not Neuron:IsHooked(WorldFrame, "OnMouseDown") then
-		Neuron:HookScript(WorldFrame, "OnMouseDown", function() ACTIONBUTTON:WorldFrame_OnReceiveDrag() end)
+		Neuron:HookScript(WorldFrame, "OnMouseDown", function() ActionButton:WorldFrame_OnReceiveDrag() end)
 	end
 
 	self:SetScript("OnAttributeChanged", function(_, name, value) self:OnAttributeChanged(name, value) end)
@@ -190,7 +190,7 @@ function ACTIONBUTTON:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function ACTIONBUTTON:InitializeButtonSettings()
+function ActionButton:InitializeButtonSettings()
 	self:SetFrameStrata(Neuron.STRATAS[self.bar:GetStrata()-1])
 	self:SetScale(self.bar:GetBarScale())
 
@@ -229,7 +229,7 @@ function ACTIONBUTTON:InitializeButtonSettings()
 end
 
 
-function ACTIONBUTTON:SetupEvents()
+function ActionButton:SetupEvents()
 	self:RegisterEvent("PLAYER_ENTERING_WORLD")
 
 	self:RegisterEvent("UPDATE_MACROS")
@@ -280,7 +280,7 @@ function ACTIONBUTTON:SetupEvents()
 	end
 end
 
-function ACTIONBUTTON:OnAttributeChanged(name, value)
+function ActionButton:OnAttributeChanged(name, value)
 
 	if value and self.data then
 		if name == "activestate" then
@@ -343,7 +343,7 @@ function ACTIONBUTTON:OnAttributeChanged(name, value)
 end
 
 
-function ACTIONBUTTON:OnLeave(...)
+function ActionButton:OnLeave(...)
 	GameTooltip:Hide()
 
 	if self.flyout and self.flyout.arrow then
@@ -355,11 +355,11 @@ end
 --------------General Button Methods------------------------
 ------------------------------------------------------------
 
-function ACTIONBUTTON:GetDragAction()
+function ActionButton:GetDragAction()
 	return "macro"
 end
 
-function ACTIONBUTTON:ClearButton(clearAttributes)
+function ActionButton:ClearButton(clearAttributes)
 	self.spell = nil
 	self.spellID = nil
 	self.item = nil
@@ -376,7 +376,7 @@ function ACTIONBUTTON:ClearButton(clearAttributes)
 	end
 end
 
-function ACTIONBUTTON:UpdateGlow()
+function ActionButton:UpdateGlow()
 	if self.bar:GetSpellGlow() and self.spellID then
 		--druid fix for thrash glow not showing for feral druids.
 		--Thrash Guardian: 77758
@@ -402,7 +402,7 @@ function ACTIONBUTTON:UpdateGlow()
 end
 
 
-function ACTIONBUTTON:StartGlow()
+function ActionButton:StartGlow()
 	if self.bar:GetSpellGlow() == "default" then
 		ActionButton_ShowOverlayGlow(self)
 	else
@@ -411,7 +411,7 @@ function ACTIONBUTTON:StartGlow()
 	end
 end
 
-function ACTIONBUTTON:StopGlow()
+function ActionButton:StopGlow()
 	if self.bar:GetSpellGlow() == "default" then
 		ActionButton_HideOverlayGlow(self)
 	else
@@ -424,7 +424,7 @@ end
 ---------------------Event Functions------------------------------------------
 ------------------------------------------------------------------------------
 
-function ACTIONBUTTON:PLAYER_ENTERING_WORLD()
+function ActionButton:PLAYER_ENTERING_WORLD()
 	self:UpdateAll()
 	self:KeybindOverlay_ApplyBindings()
 
@@ -433,20 +433,20 @@ function ACTIONBUTTON:PLAYER_ENTERING_WORLD()
 	end
 end
 
-function ACTIONBUTTON:UNIT_SPELLCAST_INTERRUPTED(unit)
+function ActionButton:UNIT_SPELLCAST_INTERRUPTED(unit)
 	if (unit == "player" or unit == "pet") and self.spell then
 		self:UpdateCooldown()
 	end
 end
 
 
-function ACTIONBUTTON:UPDATE_MACROS()
+function ActionButton:UPDATE_MACROS()
 	if not InCombatLockdown() and self:GetMacroBlizzMacro() then
 		self:PlaceBlizzMacro(self:GetMacroBlizzMacro())
 	end
 end
 
-function ACTIONBUTTON:EQUIPMENT_SETS_CHANGED()
+function ActionButton:EQUIPMENT_SETS_CHANGED()
 	if not InCombatLockdown() and self:GetMacroEquipmentSet() then
 		self:PlaceBlizzEquipSet(self:GetMacroEquipmentSet())
 	end
@@ -455,7 +455,7 @@ end
 -----------------------------------------------------------------------------------------
 -----------------------------------------------------------------------------------------
 
-function ACTIONBUTTON:ParseAndSanitizeMacro()
+function ActionButton:ParseAndSanitizeMacro()
 	local uncleanMacro = self:GetMacroText()
 	if #uncleanMacro > 0 then
 		--adds an empty line above and below the macro
@@ -467,7 +467,7 @@ function ACTIONBUTTON:ParseAndSanitizeMacro()
 	end
 end
 
-function ACTIONBUTTON:UpdateButtonSpec()
+function ActionButton:UpdateButtonSpec()
 	local spec = (self.bar:GetMultiSpec() and Neuron.isWoWRetail) and GetSpecialization() or 1
 
 	self:LoadDataFromDatabase(spec, self.bar.handler:GetAttribute("activestate") or "homestate")
@@ -477,7 +477,7 @@ function ACTIONBUTTON:UpdateButtonSpec()
 end
 
 --this function is used to "fake" a state change in the button editor so you can see what each state will look like
-function ACTIONBUTTON:FakeStateChange(state)
+function ActionButton:FakeStateChange(state)
 	if state then
 
 		local msg = (":"):split(state)
@@ -541,7 +541,7 @@ end
 --spell: name of spell to use
 --subname: subname of spell to use (optional)
 --return: macro text
-function ACTIONBUTTON:AutoWriteMacro(spell)
+function ActionButton:AutoWriteMacro(spell)
 	local DB = Neuron.db.profile
 
 	local spellName
@@ -600,7 +600,7 @@ function ACTIONBUTTON:AutoWriteMacro(spell)
 	return "#autowrite\n/cast"..modifier..spell.."()"
 end
 
-function ACTIONBUTTON:GetPosition(relFrame)
+function ActionButton:GetPosition(relFrame)
 	local point
 
 	if not relFrame then
@@ -633,7 +633,7 @@ end
 --This will update the modifier value in a macro when a bar is set with a target conditional
 --@spell:  this is hte macro text to be updated
 --return: updated macro text
---[[function ACTIONBUTTON:AutoUpdateMacro(macro)
+--[[function ActionButton:AutoUpdateMacro(macro)
 
 	local DB = Neuron.db.profile
 
@@ -664,7 +664,7 @@ end
 -- macro will then be updated to via AutoWriteMacro to include selected target macro option, or via AutoUpdateMacro
 -- to update a current target macro's toggle modifier.
 -- @param global(boolean): if true will go though all buttons, else it will just update the button set for the current bar
-function ACTIONBUTTON:UpdateMacroCastTargets(global_update)
+function ActionButton:UpdateMacroCastTargets(global_update)
 
 	local button_list = {}
 
@@ -720,18 +720,18 @@ end]]
 --------------------- Overrides ---------------------
 -----------------------------------------------------
 
---overwrite function in parent class BUTTON
-function ACTIONBUTTON:UpdateAll()
+--overwrite function in parent class Button
+function ActionButton:UpdateAll()
 	--pass to parent UpdateAll function
-	Neuron.BUTTON.UpdateAll(self)
+	Neuron.Button.UpdateAll(self)
 
 	if Neuron.isWoWRetail then
 		self:UpdateGlow()
 	end
 end
 
---overwrite function in parent class BUTTON
-function ACTIONBUTTON:UpdateData()
+--overwrite function in parent class Button
+function ActionButton:UpdateData()
 	--clear any lingering values before we re-parse and reassign
 	self:ClearButton()
 
@@ -790,8 +790,8 @@ function ACTIONBUTTON:UpdateData()
 	end
 end
 
---overwrite function in parent class BUTTON
-function ACTIONBUTTON:UpdateVisibility(show)
+--overwrite function in parent class Button
+function ActionButton:UpdateVisibility(show)
 	if self:HasAction() or Neuron.dragging or show or self.bar:GetShowGrid() or Neuron.buttonEditMode or Neuron.barEditMode or Neuron.bindingMode then
 		self.isShown = true
 	else
@@ -808,5 +808,5 @@ function ACTIONBUTTON:UpdateVisibility(show)
 		end
 	end
 
-	Neuron.BUTTON.UpdateVisibility(self)
+	Neuron.Button.UpdateVisibility(self)
 end

--- a/Objects/ActionButton_DragAndDrop.lua
+++ b/Objects/ActionButton_DragAndDrop.lua
@@ -6,10 +6,10 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----The functions in this file are part of the ACTIONBUTTON class.
+---The functions in this file are part of the ActionButton class.
 ---It was just easier to put them all in their own file for organization.
 
-local ACTIONBUTTON = Neuron.ACTIONBUTTON
+local ActionButton = Neuron.ActionButton
 
 local macroDrag = {} --this is a table that holds onto the contents of the  current macro being dragged
 local macroCache = {} --this will hold onto any previous contents of our button
@@ -20,7 +20,7 @@ local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 --------------------------------------
 
 --this is the function that fires when you begin dragging an item
-function ACTIONBUTTON:OnDragStart()
+function ActionButton:OnDragStart()
 	if InCombatLockdown() or not self.bar or self.actionID then
 		return
 	end
@@ -61,7 +61,7 @@ function ACTIONBUTTON:OnDragStart()
 end
 
 --This is the function that fires when a button is receiving a dragged item
-function ACTIONBUTTON:OnReceiveDrag()
+function ActionButton:OnReceiveDrag()
 	if InCombatLockdown() then --don't allow moving or changing macros while in combat. This will cause taint
 		return
 	end
@@ -135,7 +135,7 @@ function ACTIONBUTTON:OnReceiveDrag()
 end
 
 
-function ACTIONBUTTON:PostClick() --this is necessary because if you are daisy-chain dragging spells to the bar you wont be able to place the last one due to it not firing an OnReceiveDrag
+function ActionButton:PostClick() --this is necessary because if you are daisy-chain dragging spells to the bar you wont be able to place the last one due to it not firing an OnReceiveDrag
 	if #macroDrag>0 then
 		self:OnReceiveDrag()
 	end
@@ -143,7 +143,7 @@ function ACTIONBUTTON:PostClick() --this is necessary because if you are daisy-c
 end
 
 --we need to hook to the WorldFrame OnReceiveDrag and OnMouseDown so that we can "let go" of the spell when we drag it off the bar
-function ACTIONBUTTON:WorldFrame_OnReceiveDrag()
+function ActionButton:WorldFrame_OnReceiveDrag()
 	SetCursor(nil)
 	ClearCursor()
 	Neuron.dragging = false
@@ -162,7 +162,7 @@ end
 --------------------------------------
 
 
-function ACTIONBUTTON:PickUpMacro()
+function ActionButton:PickUpMacro()
 
 	if macroCache[1] then  --triggers when picking up an existing button with a button in the cursor
 
@@ -199,7 +199,7 @@ function ACTIONBUTTON:PickUpMacro()
 end
 
 
-function ACTIONBUTTON:PlaceMacro()
+function ActionButton:PlaceMacro()
 	self:SetMacroText(macroDrag[2])
 	self:SetMacroIcon(macroDrag[3])
 	self:SetMacroName(macroDrag[4])
@@ -209,7 +209,7 @@ function ACTIONBUTTON:PlaceMacro()
 	self:SetMacroEquipmentSet(macroDrag[8])
 end
 
-function ACTIONBUTTON:PlaceSpell(action1, action2, spellID)
+function ActionButton:PlaceSpell(action1, action2, spellID)
 	local spell
 
 	if action1 == 0 then
@@ -244,7 +244,7 @@ function ACTIONBUTTON:PlaceSpell(action1, action2, spellID)
 	self:SetMacroEquipmentSet()
 end
 
-function ACTIONBUTTON:PlacePetAbility(action1, action2)
+function ActionButton:PlacePetAbility(action1, action2)
 
 	local spellID = action1
 	local spellIndex = action2
@@ -266,7 +266,7 @@ function ACTIONBUTTON:PlacePetAbility(action1, action2)
 end
 
 
-function ACTIONBUTTON:PlaceItem(action1, action2)
+function ActionButton:PlaceItem(action1, action2)
 	local item, link = GetItemInfo(action2)
 
 	if link and not Neuron.itemCache[item:lower()] then --add the item to the itemcache if it isn't otherwise in it
@@ -290,7 +290,7 @@ function ACTIONBUTTON:PlaceItem(action1, action2)
 end
 
 
-function ACTIONBUTTON:PlaceBlizzMacro(action1)
+function ActionButton:PlaceBlizzMacro(action1)
 	if action1 == 0 then
 		return
 	end
@@ -315,7 +315,7 @@ function ACTIONBUTTON:PlaceBlizzMacro(action1)
 end
 
 
-function ACTIONBUTTON:PlaceBlizzEquipSet(equipmentSetName)
+function ActionButton:PlaceBlizzEquipSet(equipmentSetName)
 	if equipmentSetName == 0 then
 		return
 	end
@@ -357,7 +357,7 @@ end
 --Based on discussion thread http://www.wowinterface.com/forums/showthread.php?t=49599&page=2
 --More dynamic than the manual list that was originally implement
 
-function ACTIONBUTTON:PlaceMount(action1, action2)
+function ActionButton:PlaceMount(action1, action2)
 	local mountName, mountSpellID, mountIcon = C_MountJournal.GetMountInfoByID(action1)
 	local mountSpell
 
@@ -384,7 +384,7 @@ function ACTIONBUTTON:PlaceMount(action1, action2)
 end
 
 
-function ACTIONBUTTON:PlaceCompanion(action1, action2)
+function ActionButton:PlaceCompanion(action1, action2)
 	if action1 == 0 then
 		return
 	end
@@ -407,7 +407,7 @@ function ACTIONBUTTON:PlaceCompanion(action1, action2)
 	self:SetMacroEquipmentSet()
 end
 
-function ACTIONBUTTON:PlaceBattlePet(action1, action2)
+function ActionButton:PlaceBattlePet(action1, action2)
 	if action1 == 0 then
 		return
 	end
@@ -424,7 +424,7 @@ function ACTIONBUTTON:PlaceBattlePet(action1, action2)
 end
 
 
-function ACTIONBUTTON:PlaceFlyout(action1, action2)
+function ActionButton:PlaceFlyout(action1, action2)
 	if action1 == 0 then
 		return
 	end
@@ -476,7 +476,7 @@ end
 
 --This is all just to put an icon on the mouse cursor. Sadly we can't use SetCursor, because once you leave the frame the icon goes away. PickupSpell seems to work, but we need a valid spellID
 --This trick here is that we ignore what is 'actually' and are just using it for the icon and the sound effects
-function ACTIONBUTTON:SetMouseCursor()
+function ActionButton:SetMouseCursor()
 	ClearCursor()
 
 	if self.spell and self.spellID then

--- a/Objects/ActionButton_Flyout.lua
+++ b/Objects/ActionButton_Flyout.lua
@@ -6,8 +6,8 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
-local ACTIONBUTTON = Neuron.ACTIONBUTTON
-local BAR = Neuron.BAR
+local ActionButton = Neuron.ActionButton
+local Bar = Neuron.Bar
 
 local petIcons = {}
 
@@ -18,11 +18,11 @@ local timersRunning = {} -- indexed numerically, timers that are running
 
 local barsToUpdate = {}
 
-local FOBARIndex, FOBTNIndex, ANCHORIndex = {}, {}, {}
+local FOBarIndex, FOBtnIndex, AnchorIndex = {}, {}, {}
 
-Neuron.FOBARIndex = FOBARIndex
-Neuron.FOBTNIndex = FOBTNIndex
-Neuron.ANCHORIndex = ANCHORIndex
+Neuron.FOBarIndex = FOBarIndex
+Neuron.FOBtnIndex = FOBtnIndex
+Neuron.AnchorIndex = AnchorIndex
 
 --[[ Timer Management ]]
 local timerFrame
@@ -185,7 +185,7 @@ end
 ---@param keyPrefixes string|table<number,table<string,Key>> keys as a comma separated string or list of name,value pairs. Matched keys have value: true.
 ---@param negativeKeyPrefixes string|table<number,table<string,Key>> keys as a comma separated string or list of name,value pairs. Matched keys have value: false.
 ---@param useDefault boolean flag whether or not to use default rules (table<name:string,value:Key: string> {"MustNot","!"}{"Optional","~"}{"Slot","#"})
-function ACTIONBUTTON:getCriteria(rules,negativeRules, useDefault)
+function ActionButton:getCriteria(rules,negativeRules, useDefault)
 	if type(rules) == "boolean" and negativeRules == nil and useDefault == nil then
 		useDefault = rules
 		rules = nil
@@ -310,7 +310,7 @@ end
 --- Filter handler for items
 -- item:id will get all items of that itemID
 -- item:name will get all items that contain "name" in its name
-function ACTIONBUTTON:filter_item(tooltip)
+function ActionButton:filter_item(tooltip)
 	local data, itemTooltips, Criteria = {},{}, self:getCriteria()
 	-- build tooltip table
 	if (tooltip) then -- part I of tooltip cache version
@@ -415,7 +415,7 @@ end
 --- Filter Handler for Spells
 -- spell:id will get all spells of that spellID
 -- spell:name will get all spells that contain "name" in its name or its flyout parent
-function ACTIONBUTTON:filter_spell(tooltip)
+function ActionButton:filter_spell(tooltip)
 	local data, spellTooltips, Criteria = {},{}, self:getCriteria()
 	-- build tooltip table
 	if (tooltip) then
@@ -496,7 +496,7 @@ end
 ---Filter handler for item type
 -- type:quest will get all quest items in bags, or those on person with Quest in a type field
 -- type:name will get all items that have "name" in its type, subtype or slot name
-function ACTIONBUTTON:filter_type()
+function ActionButton:filter_type()
 	local data, itemTypes, Criteria = {},{}, self:getCriteria()
 	itemTypes = nil
 	--should this search tooltip by default? does the tooltip contain the type?
@@ -554,7 +554,7 @@ end
 --- Filter handler for mounts
 -- mount:any, mount:flying, mount:land, mount:favorite, mount:fflying, mount:fland
 -- mount:arg filters mounts that include arg in the name or arg="flying" or arg="land" or arg=="any"
-function ACTIONBUTTON:filter_mount()
+function ActionButton:filter_mount()
 	local keys, found, mandatory, optional = self.flyout.keys, 0, 0, 0
 
 	local data = {}
@@ -602,7 +602,7 @@ end
 --- Filter handler for professions
 --- not WoW Classic
 -- profession:arg filters professions that include arg in the name or arg="primary" or arg="secondary" or arg="all"
-function ACTIONBUTTON:filter_profession()
+function ActionButton:filter_profession()
 
 	local data = {}
 
@@ -652,7 +652,7 @@ end
 --- Filter handler for companion pets
 --- not WoW Classic
 -- pet:arg filters companion pets that include arg in the name or arg="any" or arg="favorite(s)"
-function ACTIONBUTTON:filter_pet()
+function ActionButton:filter_pet()
 
 	local data = {}
 
@@ -675,7 +675,7 @@ end
 ---Filter handler for toy items
 --- not WoW Classic
 -- toy:arg filters items from the toybox; arg="favorite" "any" or partial name
-function ACTIONBUTTON:filter_toy()
+function ActionButton:filter_toy()
 	local keys, found, mandatory, optional = self.flyout.keys, 0, 0, 0
 
 	local data = {}
@@ -700,7 +700,7 @@ end
 
 
 --- Handler for Blizzard flyout spells
-function ACTIONBUTTON:GetBlizzData()
+function ActionButton:GetBlizzData()
 
 	local data = {}
 
@@ -728,7 +728,7 @@ end
 
 
 --- Flyout type handler
-function ACTIONBUTTON:GetDataList(options)
+function ActionButton:GetDataList(options)
 	local tooltip
 
 	local scanData = {}
@@ -757,7 +757,7 @@ function ACTIONBUTTON:GetDataList(options)
 	return scanData
 end
 
-function ACTIONBUTTON:updateFlyoutBars()
+function ActionButton:updateFlyoutBars()
 	if not InCombatLockdown() then  --Workaround for protected taint if UI reload in combat
 		local bar = table.remove(barsToUpdate) --this does nothing. It makes bar empty
 
@@ -771,7 +771,7 @@ function ACTIONBUTTON:updateFlyoutBars()
 	end
 end
 
-function ACTIONBUTTON:Flyout_UpdateData(init)
+function ActionButton:Flyout_UpdateData(init)
 	local slot
 	local pet = false
 
@@ -900,7 +900,7 @@ function ACTIONBUTTON:Flyout_UpdateData(init)
 	end
 end
 
-function ACTIONBUTTON:Flyout_UpdateBar()
+function ActionButton:Flyout_UpdateBar()
 	self.FlyoutTop:Hide()
 	self.FlyoutBottom:Hide()
 	self.FlyoutLeft:Hide()
@@ -1005,13 +1005,13 @@ function ACTIONBUTTON:Flyout_UpdateBar()
 end
 
 
-function ACTIONBUTTON:Flyout_RemoveButtons()
+function ActionButton:Flyout_RemoveButtons()
 	for _,button in pairs(self.flyout.buttons) do
 		self:Flyout_ReleaseButton(button)
 	end
 end
 
-function ACTIONBUTTON:Flyout_RemoveBar()
+function ActionButton:Flyout_RemoveBar()
 	self.FlyoutTop:Hide()
 	self.FlyoutBottom:Hide()
 	self.FlyoutLeft:Hide()
@@ -1022,7 +1022,7 @@ function ACTIONBUTTON:Flyout_RemoveBar()
 	self:Flyout_ReleaseBar(self.flyout.bar)
 end
 
-function ACTIONBUTTON:UpdateFlyout(init)
+function ActionButton:UpdateFlyout(init)
 	local options
 
 	if self:GetMacroText() then
@@ -1060,15 +1060,15 @@ function ACTIONBUTTON:UpdateFlyout(init)
 
 		self.bar.watchframes[self.flyout.bar.handler] = true
 
-		ANCHORIndex[self] = true
+		AnchorIndex[self] = true
 	else
-		ANCHORIndex[self] = nil
+		AnchorIndex[self] = nil
 		self.flyout = nil
 	end
 end
 
 
-function ACTIONBUTTON:Flyout_ReleaseButton(button)
+function ActionButton:Flyout_ReleaseButton(button)
 	self.flyout.buttons[button.id] = nil
 
 	button.stored = true
@@ -1092,7 +1092,7 @@ function ACTIONBUTTON:Flyout_ReleaseButton(button)
 end
 
 
-function ACTIONBUTTON:Flyout_InitializeButtonSettings(bar)
+function ActionButton:Flyout_InitializeButtonSettings(bar)
 	if bar then
 		self.bar = bar
 		self.bar.data.tooltips = "normal"
@@ -1105,7 +1105,7 @@ function ACTIONBUTTON:Flyout_InitializeButtonSettings(bar)
 end
 
 
-function ACTIONBUTTON:Flyout_PostClick()
+function ActionButton:Flyout_PostClick()
 	local button = self.anchor
 
 	button:SetMacroText(self:GetAttribute("flyoutMacro"))
@@ -1119,9 +1119,9 @@ function ACTIONBUTTON:Flyout_PostClick()
 	self:UpdateStatus()
 end
 
-function ACTIONBUTTON:Flyout_GetButton()
+function ActionButton:Flyout_GetButton()
 	local id = 1
-	for _,button in ipairs(FOBTNIndex) do
+	for _,button in ipairs(FOBtnIndex) do
 		if button.stored then
 			button.anchor = self
 			button.bar = self.flyout.bar
@@ -1137,7 +1137,7 @@ function ACTIONBUTTON:Flyout_GetButton()
 	end
 
 	local newButton = CreateFrame("CheckButton", self:GetName().."_".."NeuronFlyoutButton"..id, UIParent, "NeuronActionButtonTemplate") --create the new button frame using the desired parameters
-	setmetatable(newButton, {__index = ACTIONBUTTON})
+	setmetatable(newButton, {__index = ActionButton})
 
 	newButton.elapsed = 0
 
@@ -1146,7 +1146,7 @@ function ACTIONBUTTON:Flyout_GetButton()
 	newButton:SetID(0)
 	newButton:SetToplevel(true)
 	newButton.objTIndex = id
-	newButton.objType = "FLYOUTBUTTON"
+	newButton.objType = "FLYOUTButton"
 	newButton.data = { macro_Text = "" }
 
 	newButton.anchor = self
@@ -1184,7 +1184,7 @@ function ACTIONBUTTON:Flyout_GetButton()
 
 
 	--link objects to their associated functions
-	newButton.InitializeButtonSettings = ACTIONBUTTON.Flyout_InitializeButtonSettings
+	newButton.InitializeButtonSettings = ActionButton.Flyout_InitializeButtonSettings
 
 
 	newButton:InitializeButtonSettings(self.flyout.bar)
@@ -1195,12 +1195,12 @@ function ACTIONBUTTON:Flyout_GetButton()
 
 	self.flyout.buttons[id] = newButton
 
-	FOBTNIndex[id] = newButton
+	FOBtnIndex[id] = newButton
 
 	return newButton
 end
 
-function ACTIONBUTTON:Flyout_ReleaseBar(bar)
+function ActionButton:Flyout_ReleaseBar(bar)
 	self.flyout.bar = nil
 
 	bar.stored = true
@@ -1215,16 +1215,16 @@ function ACTIONBUTTON:Flyout_ReleaseBar(bar)
 	end
 end
 
-function BAR:Flyout_OnEvent()
+function Bar:Flyout_OnEvent()
 	self:SetObjectLoc()
 	self:SetPerimeter()
 	self:SetSize()
 end
 
-function ACTIONBUTTON:Flyout_GetBar()
+function ActionButton:Flyout_GetBar()
 	local id = 1
 
-	for _,bar in ipairs(FOBARIndex) do
+	for _,bar in ipairs(FOBarIndex) do
 		if bar.stored then
 			bar.stored = false
 			bar:SetParent(UIParent)
@@ -1235,7 +1235,7 @@ function ACTIONBUTTON:Flyout_GetBar()
 	end
 
 	local bar = CreateFrame("CheckButton", self:GetName().."_".."NeuronFlyoutBar"..id, UIParent, "NeuronBarTemplate")
-	setmetatable(bar, {__index = Neuron.BAR})
+	setmetatable(bar, {__index = Neuron.Bar})
 
 	bar.class = "FlyoutBar"
 	bar.elapsed = 0
@@ -1282,12 +1282,12 @@ function ACTIONBUTTON:Flyout_GetBar()
 
 	bar.handler:Hide()
 
-	FOBARIndex[id] = bar
+	FOBarIndex[id] = bar
 	return bar
 end
 
 
-function ACTIONBUTTON:Anchor_RemoveChild()
+function ActionButton:Anchor_RemoveChild()
 	local child = self.flyout.bar and self.flyout.bar.handler
 
 	if child then
@@ -1305,7 +1305,7 @@ function ACTIONBUTTON:Anchor_RemoveChild()
 	end
 end
 
-function ACTIONBUTTON:Anchor_UpdateChild()
+function ActionButton:Anchor_UpdateChild()
 	local child = self.flyout.bar and self.flyout.bar.handler
 
 	if child then
@@ -1362,7 +1362,7 @@ function ACTIONBUTTON:Anchor_UpdateChild()
 	end
 end
 
-function ACTIONBUTTON:Anchor_Update(remove)
+function ActionButton:Anchor_Update(remove)
 	if remove then
 		self:Anchor_RemoveChild()
 	else

--- a/Objects/BAR.lua
+++ b/Objects/BAR.lua
@@ -6,14 +6,14 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class BAR : CheckButton @This is our bar object that serves as the container for all of our button objects
-local BAR = setmetatable({}, {__index = CreateFrame("CheckButton")}) --this is the metatable for our button object
-Neuron.BAR = BAR
+---@class Bar : CheckButton @This is our bar object that serves as the container for all of our button objects
+local Bar = setmetatable({}, {__index = CreateFrame("CheckButton")}) --this is the metatable for our button object
+Neuron.Bar = Bar
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
-LibStub("AceTimer-3.0"):Embed(BAR)
-LibStub("AceEvent-3.0"):Embed(BAR)
+LibStub("AceTimer-3.0"):Embed(Bar)
+LibStub("AceEvent-3.0"):Embed(Bar)
 
 local alphaDir, alphaTimer = 0, 0
 
@@ -24,11 +24,11 @@ TRASHCAN:Hide()
 
 ----------------------------------------------------
 
----Constructor: Create a new Neuron BAR object
+---Constructor: Create a new Neuron Bar object
 ---@param class string @The class type of the new bar
 ---@param barID number @The ID of the new bar object
----@return BAR @ A newly created BUTTON object
-function BAR.new(class, barID)
+---@return Bar @ A newly created Button object
+function Bar.new(class, barID)
 	local data = Neuron.registeredBarData[class]
 
 	local newBar
@@ -36,10 +36,10 @@ function BAR.new(class, barID)
 	--this is the creation of our bar object frame
 	if _G["Neuron"..data.barType..barID] then --check to see if our bar already exists on the global namespace
 		newBar = CreateFrame("CheckButton", "Neuron"..data.barType..random(1000,10000000), UIParent, "NeuronBarTemplate") --in the case of trying to create a bar on a frame that already exists, create a random frame ID for this session only
-		setmetatable(newBar, {__index = BAR})
+		setmetatable(newBar, {__index = Bar})
 	else
 		newBar = CreateFrame("CheckButton", "Neuron"..data.barType..barID, UIParent, "NeuronBarTemplate")
-		setmetatable(newBar, {__index = BAR})
+		setmetatable(newBar, {__index = Bar})
 	end
 
 	--load saved data
@@ -112,7 +112,7 @@ function BAR.new(class, barID)
 	return newBar
 end
 
-function BAR:InitializeBar()
+function Bar:InitializeBar()
 	if self.class == "ActionBar" then
 		if Neuron.isWoWRetail or Neuron.isWoWWrathClassic then
 			self:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
@@ -126,7 +126,7 @@ end
 --------- Event Handlers ----------
 -----------------------------------
 
-function BAR:ACTIVE_TALENT_GROUP_CHANGED()
+function Bar:ACTIVE_TALENT_GROUP_CHANGED()
 	if self.handler:GetAttribute("assertstate") then
 		self.handler:SetAttribute("state-"..self.handler:GetAttribute("assertstate"), self.handler:GetAttribute("activestate") or "homestate")
 	end
@@ -136,7 +136,7 @@ function BAR:ACTIVE_TALENT_GROUP_CHANGED()
 	end
 end
 
-function BAR:ACTIONBAR_SHOWHIDEGRID(show)
+function Bar:ACTIONBAR_SHOWHIDEGRID(show)
 
 	if show then
 		Neuron.dragging = true
@@ -162,8 +162,8 @@ end
 -----Bar Add/Remove Functions------
 -----------------------------------
 
----This function is used for creating brand new bars, and it is really just a wrapper for the BAR constructor with a couple of assumptions and checks
-function BAR:CreateNewBar(class)
+---This function is used for creating brand new bars, and it is really just a wrapper for the Bar constructor with a couple of assumptions and checks
+function Bar:CreateNewBar(class)
 
 	if not class and Neuron.registeredBarData[class] then --if the class isn't registered, go ahead and bail out.
 		Neuron.PrintBarTypes()
@@ -172,18 +172,18 @@ function BAR:CreateNewBar(class)
 
 	local barID = #Neuron.registeredBarData[class].barDB + 1 --increment 1 higher than the current number of bars in this class of bar's database
 
-	local newBar = BAR.new(class, barID) --create new bar
+	local newBar = Bar.new(class, barID) --create new bar
 
 	newBar.objTemplate.new(newBar, 1) --add at least 1 button to a new bar
-	BAR.ChangeSelectedBar(newBar)
+	Bar.ChangeSelectedBar(newBar)
 	newBar:Load() --load the bar
 
 	newBar:Show() --Show the transparent blue overlay that we show in the edit mode
 end
-Neuron.CreateNewBar = BAR.CreateNewBar --this is so the slash function works correctly
+Neuron.CreateNewBar = Bar.CreateNewBar --this is so the slash function works correctly
 
 
-function BAR:DeleteBar()
+function Bar:DeleteBar()
 	self.handler:SetAttribute("state-current", "homestate")
 	self.handler:SetAttribute("state-last", "homestate")
 	self.handler:SetAttribute("showstates", "homestate")
@@ -255,7 +255,7 @@ function BAR:DeleteBar()
 	end
 end
 
-function BAR:AddObjectToBar() --called from NeuronGUI
+function Bar:AddObjectToBar() --called from NeuronGUI
 	local id = #self.buttons + 1
 
 	if #self.buttons < self.objMax then
@@ -271,7 +271,7 @@ function BAR:AddObjectToBar() --called from NeuronGUI
 	self:UpdateObjectVisibility()
 end
 
-function BAR:RemoveObjectFromBar() --called from NeuronGUI
+function Bar:RemoveObjectFromBar() --called from NeuronGUI
 
 	local id = #self.buttons --always the last button
 
@@ -298,7 +298,7 @@ function BAR:RemoveObjectFromBar() --called from NeuronGUI
 end
 
 
-function BAR:Load()
+function Bar:Load()
 	self:SetPosition()
 	self:LoadObjects()
 	self:SetObjectLoc()
@@ -308,7 +308,7 @@ function BAR:Load()
 	self:UpdateBarStatus()
 end
 
-function BAR.ChangeSelectedBar(newBar)
+function Bar.ChangeSelectedBar(newBar)
 	if newBar and Neuron.currentBar ~= newBar then
 		Neuron.currentBar = newBar
 
@@ -363,7 +363,7 @@ end
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 
-function BAR.IsMouseOverSelfOrWatchFrame(frame)
+function Bar.IsMouseOverSelfOrWatchFrame(frame)
 	if frame:IsMouseOver() then
 		return true
 	end
@@ -381,13 +381,13 @@ end
 
 
 ---this function is set via a repeating scheduled timer in SetAutoHide()
-function BAR:AutoHideUpdate()
+function Bar:AutoHideUpdate()
 	if self:GetAutoHide() and self.handler~=nil then
 		if not Neuron.buttonEditMode and not Neuron.barEditMode and not Neuron.bindingMode then
 			if self:IsShown() then
 				self.handler:SetAlpha(1)
 			else
-				if BAR.IsMouseOverSelfOrWatchFrame(self) then
+				if Bar.IsMouseOverSelfOrWatchFrame(self) then
 					if self.handler:GetAlpha() < self:GetBarAlpha() then
 						if self.handler:GetAlpha()+self:GetAlphaUpSpeed() <= 1 then
 							self.handler:SetAlpha(self.handler:GetAlpha()+self:GetAlphaUpSpeed())
@@ -396,7 +396,7 @@ function BAR:AutoHideUpdate()
 						end
 					end
 				end
-				if not BAR.IsMouseOverSelfOrWatchFrame(self) then
+				if not Bar.IsMouseOverSelfOrWatchFrame(self) then
 					if self.handler:GetAlpha() > 0 then
 						if self.handler:GetAlpha()-self:GetAlphaUpSpeed() >= 0 then
 							self.handler:SetAlpha(self.handler:GetAlpha()-self:GetAlphaUpSpeed())
@@ -410,7 +410,7 @@ function BAR:AutoHideUpdate()
 	end
 end
 
-function BAR:AlphaUpUpdate()
+function Bar:AlphaUpUpdate()
 	if self:GetAlphaUp() == "combat" then
 		if InCombatLockdown() then
 			if self.handler:GetAlpha() < 1 then
@@ -430,7 +430,7 @@ function BAR:AlphaUpUpdate()
 			end
 		end
 	elseif self:GetAlphaUp() == "combat + mouseover" then
-		if InCombatLockdown() and BAR.IsMouseOverSelfOrWatchFrame(self)  then
+		if InCombatLockdown() and Bar.IsMouseOverSelfOrWatchFrame(self)  then
 			if self.handler:GetAlpha() < 1 then
 				if self.handler:GetAlpha()+self:GetAlphaUpSpeed() <= 1 then
 					self.handler:SetAlpha(self.handler:GetAlpha()+self:GetAlphaUpSpeed())
@@ -448,7 +448,7 @@ function BAR:AlphaUpUpdate()
 			end
 		end
 	elseif self:GetAlphaUp() == "mouseover" then
-		if BAR.IsMouseOverSelfOrWatchFrame(self) then
+		if Bar.IsMouseOverSelfOrWatchFrame(self) then
 			if self.handler:GetAlpha() < 1 then
 				if self.handler:GetAlpha()+self:GetAlphaUpSpeed() <= 1 then
 					self.handler:SetAlpha(self.handler:GetAlpha()+self:GetAlphaUpSpeed())
@@ -468,7 +468,7 @@ function BAR:AlphaUpUpdate()
 	end
 end
 
-function BAR:UpdateAutoHideTimer()
+function Bar:UpdateAutoHideTimer()
 	if self:GetAutoHide() then
 		if self:TimeLeft(self.autoHideTimer) == 0 then --safety check to make sure we don't re-set an already active timer
 			self.autoHideTimer = self:ScheduleRepeatingTimer("AutoHideUpdate", 0.05)
@@ -478,7 +478,7 @@ function BAR:UpdateAutoHideTimer()
 	end
 end
 
-function BAR:UpdateAlphaUpTimer()
+function Bar:UpdateAlphaUpTimer()
 	if self:GetAlphaUp() ~= "off" then
 		if self:TimeLeft(self.alphaUpTimer) == 0 then --safety check to make sure we don't re-set an already active timer
 			self.alphaUpTimer = self:ScheduleRepeatingTimer("AlphaUpUpdate", 0.05)
@@ -489,7 +489,7 @@ function BAR:UpdateAlphaUpTimer()
 end
 
 
-function BAR:AddVisibilityDriver(handler, state, conditions)
+function Bar:AddVisibilityDriver(handler, state, conditions)
 	if Neuron.MANAGED_BAR_STATES[state] then
 		RegisterAttributeDriver(handler, "state-"..state, conditions);
 
@@ -508,7 +508,7 @@ function BAR:AddVisibilityDriver(handler, state, conditions)
 end
 
 
-function BAR:ClearVisibilityDriver(handler, state)
+function Bar:ClearVisibilityDriver(handler, state)
 	UnregisterAttributeDriver(handler, "state-"..state)
 	handler:SetAttribute("activestates", handler:GetAttribute("activestates"):gsub(state.."%d+;", ""))
 	handler:SetAttribute("state-current", "homestate")
@@ -517,7 +517,7 @@ function BAR:ClearVisibilityDriver(handler, state)
 end
 
 
-function BAR:UpdateBarVisibility(driver)
+function Bar:UpdateBarVisibility(driver)
 	for state, values in pairs(Neuron.MANAGED_BAR_STATES) do
 		if self.data.hidestates:find(":"..state) then
 			if not self.vis[state] or not self.vis[state].registered then
@@ -536,7 +536,7 @@ function BAR:UpdateBarVisibility(driver)
 	end
 end
 
-function BAR:BuildStateMap(remapState)
+function Bar:BuildStateMap(remapState)
 	local statemap, state, map, remap, homestate = "", remapState:gsub("paged", "bar")
 	for states in gmatch(self.data.remap, "[^;]+") do
 		map, remap = (":"):split(states)
@@ -562,7 +562,7 @@ function BAR:BuildStateMap(remapState)
 end
 
 
-function BAR:AddStates(handler, state, conditions)
+function Bar:AddStates(handler, state, conditions)
 	if state then
 		if Neuron.MANAGED_BAR_STATES[state] then
 			RegisterAttributeDriver(handler, "state-"..state, conditions);
@@ -574,7 +574,7 @@ function BAR:AddStates(handler, state, conditions)
 	end
 end
 
-function BAR:ClearStates(handler, state)
+function Bar:ClearStates(handler, state)
 	if state ~= "homestate" then
 		if Neuron.MANAGED_BAR_STATES[state].homestate then
 			handler:SetAttribute("handler-homestate", nil)
@@ -588,7 +588,7 @@ function BAR:ClearStates(handler, state)
 end
 
 
-function BAR:UpdateStates(handler)
+function Bar:UpdateStates(handler)
 	for state, values in pairs(Neuron.MANAGED_BAR_STATES) do
 		if self.data[state] then
 			if not self[state] or not self[state].registered then
@@ -617,7 +617,7 @@ function BAR:UpdateStates(handler)
 end
 
 
-function BAR:CreateDriver()
+function Bar:CreateDriver()
 	--This is the macro base that will be used to set state
 	local DRIVER_BASE_ACTION = [[
 	local state = self:GetAttribute("state-<MODIFIER>"):match("%a+")
@@ -652,7 +652,7 @@ function BAR:CreateDriver()
 end
 
 
-function BAR:CreateHandler()
+function Bar:CreateHandler()
 	local HANDLER_BASE_ACTION = [[
 	if self:GetAttribute("state-<MODIFIER>") == "laststate" then
 
@@ -888,7 +888,7 @@ function BAR:CreateHandler()
 end
 
 
-function BAR:CreateWatcher()
+function Bar:CreateWatcher()
 	local watcher = CreateFrame("Frame", "NeuronBarWatcher"..self.id, self.handler, "SecureHandlerStateTemplate")
 
 	watcher:SetID(self.id)
@@ -913,7 +913,7 @@ function BAR:CreateWatcher()
 	RegisterAttributeDriver(watcher, "state-".."petbattle", "[petbattle] hide; [nopetbattle] show");
 end
 
-function BAR:UpdateBarStatus(show)
+function Bar:UpdateBarStatus(show)
 	if InCombatLockdown() then
 		return
 	end
@@ -936,7 +936,7 @@ end
 -------------------------------------------------------
 
 
-function BAR:GetPosition(oFrame)
+function Bar:GetPosition(oFrame)
 	local relFrame, point
 
 	if oFrame then
@@ -976,7 +976,7 @@ function BAR:GetPosition(oFrame)
 end
 
 
-function BAR:SetPosition()
+function Bar:SetPosition()
 	if self.data.snapToPoint and self.data.snapToFrame then
 		self:StickToPoint(_G[self.data.snapToFrame], self.data.snapToPoint,self:GetHorizontalPad(), self:GetVerticalPad())
 	else
@@ -1003,7 +1003,7 @@ function BAR:SetPosition()
 end
 
 --Fakes a state change for a given bar, calls up the counterpart function in NeuronButton
-function BAR:FakeStateChange(state)
+function Bar:FakeStateChange(state)
 	self.handler:SetAttribute("fauxstate", state)
 
 	for i, object in ipairs(self.buttons) do
@@ -1013,7 +1013,7 @@ function BAR:FakeStateChange(state)
 end
 
 --loads all the object stored for a given bar
-function BAR:LoadObjects()
+function Bar:LoadObjects()
 	local spec = (not self:GetMultiSpec() or Neuron.isWoWClassicEra) and 1 or GetSpecialization()
 
 	for i, object in ipairs(self.buttons) do
@@ -1025,7 +1025,7 @@ function BAR:LoadObjects()
 end
 
 
-function BAR:SetObjectLoc()
+function Bar:SetObjectLoc()
 	local width, height, num, origCol = 0, 0, 0, self:GetColumns()
 	local x, y, placed
 	local shape, padH, padV, arcStart, arcLength = self:GetBarShape(), self:GetHorizontalPad(), self:GetVerticalPad(), self:GetArcStart(), self:GetArcLength()
@@ -1046,7 +1046,7 @@ function BAR:SetObjectLoc()
 		buttons = self.buttons
 	else
 		for k,v in pairs (self.data.objectList) do
-			table.insert(buttons, Neuron.FOBTNIndex[v])
+			table.insert(buttons, Neuron.FOBtnIndex[v])
 		end
 	end
 
@@ -1126,7 +1126,7 @@ function BAR:SetObjectLoc()
 end
 
 
-function BAR:SetPerimeter()
+function Bar:SetPerimeter()
 	local num = 0
 
 	--This is just for the flyout bar, it should be cleaned in the future
@@ -1142,7 +1142,7 @@ function BAR:SetPerimeter()
 		buttons = self.buttons
 	else
 		for k,v in pairs (self.data.objectList) do
-			table.insert(buttons, Neuron.FOBTNIndex[v])
+			table.insert(buttons, Neuron.FOBtnIndex[v])
 		end
 	end
 	-----------------------------------------------
@@ -1179,7 +1179,7 @@ function BAR:SetPerimeter()
 end
 
 
-function BAR:SetDefaults(defaults)
+function Bar:SetDefaults(defaults)
 	for k,v in pairs(defaults) do
 		if k ~= "buttons" then --ignore this value because it's just used to tell how many buttons should be placed on a bar by default on the first load
 			self.data[k] = v
@@ -1188,7 +1188,7 @@ function BAR:SetDefaults(defaults)
 end
 
 
-function BAR:SetRemap_Paged()
+function Bar:SetRemap_Paged()
 	self.data.remap = ""
 
 	for i=1,6 do
@@ -1199,7 +1199,7 @@ function BAR:SetRemap_Paged()
 end
 
 
-function BAR:SetRemap_Stance()
+function Bar:SetRemap_Stance()
 	local start = tonumber(Neuron.MANAGED_BAR_STATES.stance.homestate:match("%d+"))
 
 	if start then
@@ -1219,7 +1219,7 @@ function BAR:SetRemap_Stance()
 end
 
 
-function BAR:SetSize()
+function Bar:SetSize()
 	if self.right then
 		self:SetWidth(((self.right-self.left)+5) * self:GetBarScale())
 		self:SetHeight(((self.top-self.bottom)+5) * self:GetBarScale())
@@ -1236,11 +1236,11 @@ end
 ------------------------OnEvent Functions-----------------------------
 ----------------------------------------------------------------------
 
-function BAR:OnClick(...)
+function Bar:OnClick(...)
 	local click, down = select(1, ...), select(2, ...)
 
 	if not down then
-		BAR.ChangeSelectedBar(self)
+		Bar.ChangeSelectedBar(self)
 	end
 
 	if IsShiftKeyDown() and not down then
@@ -1262,7 +1262,7 @@ function BAR:OnClick(...)
 
 	elseif click == "MiddleButton" then
 		if GetMouseFocus() ~= Neuron.currentBar then
-			BAR.ChangeSelectedBar(self)
+			Bar.ChangeSelectedBar(self)
 		end
 
 	elseif click == "RightButton" and not down then
@@ -1278,7 +1278,7 @@ function BAR:OnClick(...)
 end
 
 
-function BAR:OnEnter(...)
+function Bar:OnEnter(...)
 	if self:GetBarConceal() then
 		self:SetBackdropColor(1,0,0,0.6)
 	else
@@ -1289,7 +1289,7 @@ function BAR:OnEnter(...)
 end
 
 
-function BAR:OnLeave(...)
+function Bar:OnLeave(...)
 	if self ~= Neuron.currentBar then
 		if self:GetBarConceal() then
 			self:SetBackdropColor(1,0,0,0.4)
@@ -1308,8 +1308,8 @@ function BAR:OnLeave(...)
 end
 
 
-function BAR:OnDragStart(...)
-	BAR.ChangeSelectedBar(self)
+function Bar:OnDragStart(...)
+	Bar.ChangeSelectedBar(self)
 
 	self:SetFrameStrata(Neuron.STRATAS[self:GetStrata()])
 	self:EnableKeyboard(false)
@@ -1321,7 +1321,7 @@ function BAR:OnDragStart(...)
 end
 
 
-function BAR:OnDragStop(...)
+function Bar:OnDragStop(...)
 
 	local point
 	self:StopMovingOrSizing()
@@ -1357,7 +1357,7 @@ function BAR:OnDragStop(...)
 	self:UpdateBarStatus()
 end
 
-function BAR:OnKeyDown(key)
+function Bar:OnKeyDown(key)
 	if self.microAdjust then
 		self.keydown = key
 
@@ -1387,7 +1387,7 @@ function BAR:OnKeyDown(key)
 end
 
 
-function BAR:OnKeyUp(key)
+function Bar:OnKeyUp(key)
 	if self.microAdjust and not key:find("SHIFT") then
 		self.microAdjust = 1
 		self.keydown = nil
@@ -1395,7 +1395,7 @@ function BAR:OnKeyUp(key)
 end
 
 
-function BAR:OnShow()
+function Bar:OnShow()
 	if self == Neuron.currentBar then
 		if self:GetBarConceal() then
 			self:SetBackdropColor(1,0,0,0.6)
@@ -1417,7 +1417,7 @@ function BAR:OnShow()
 end
 
 
-function BAR:OnHide()
+function Bar:OnHide()
 	self.handler:SetAttribute("editmode", nil)
 
 	if self.handler:GetAttribute("vishide") then
@@ -1429,7 +1429,7 @@ function BAR:OnHide()
 end
 
 
-function BAR:Pulse(elapsed)
+function Bar:Pulse(elapsed)
 	alphaTimer = alphaTimer + elapsed * 1.5
 
 	if alphaDir == 1 then
@@ -1459,7 +1459,7 @@ end
 ---------------------------------------------------------------------------
 ---------------------------------------------------------------------------
 
-function BAR:UpdateButtonSettings()
+function Bar:UpdateButtonSettings()
 	for _, object in pairs(self.buttons) do
 		if object then
 			object:InitializeButtonSettings()
@@ -1468,7 +1468,7 @@ function BAR:UpdateButtonSettings()
 end
 
 
-function BAR:UpdateObjectVisibility(show)
+function Bar:UpdateObjectVisibility(show)
 	for _, object in pairs(self.buttons) do
 		if object then
 			object:UpdateVisibility(show)
@@ -1476,7 +1476,7 @@ function BAR:UpdateObjectVisibility(show)
 	end
 end
 
-function BAR:UpdateObjectUsability()
+function Bar:UpdateObjectUsability()
 	for _, object in pairs(self.buttons) do
 		if object then
 			object:UpdateUsable()
@@ -1484,7 +1484,7 @@ function BAR:UpdateObjectUsability()
 	end
 end
 
-function BAR:UpdateObjectIcons()
+function Bar:UpdateObjectIcons()
 	for _, object in pairs(self.buttons) do
 		if object then
 			object:UpdateIcon()
@@ -1492,7 +1492,7 @@ function BAR:UpdateObjectIcons()
 	end
 end
 
-function BAR:UpdateObjectCooldowns()
+function Bar:UpdateObjectCooldowns()
 	for _, object in pairs(self.buttons) do
 		if object then
 			object:CancelCooldownTimer(true) --this will reset the text/alpha on the button
@@ -1501,7 +1501,7 @@ function BAR:UpdateObjectCooldowns()
 	end
 end
 
-function BAR:UpdateObjectCooldowns()
+function Bar:UpdateObjectCooldowns()
 	for _, object in pairs(self.buttons) do
 		if object then
 			object:CancelCooldownTimer(true) --this will reset the text/alpha on the button
@@ -1510,7 +1510,7 @@ function BAR:UpdateObjectCooldowns()
 	end
 end
 
-function BAR:UpdateObjectStatus()
+function Bar:UpdateObjectStatus()
 	for _, object in pairs(self.buttons) do
 		if object then
 			object:UpdateStatus()
@@ -1522,23 +1522,23 @@ end
 -------------------Sets and Gets---------------------
 -----------------------------------------------------
 
-function BAR:SetBarName(name)
+function Bar:SetBarName(name)
 	if name and name ~= "" then
 		self.data.name = name
 	end
 	self:UpdateBarStatus()
 end
 
-function BAR:GetBarName()
+function Bar:GetBarName()
 	return self.data.name
 end
 
-function BAR:GetNumObjects()
+function Bar:GetNumObjects()
 	return #self.buttons
 end
 
 --TODO: Rewrite this and simplify it
-function BAR:SetState(msg, gui, checked)
+function Bar:SetState(msg, gui, checked)
 	if msg then
 		local state = msg:match("^%S+")
 		local command = msg:gsub(state, "");
@@ -1671,7 +1671,7 @@ function BAR:SetState(msg, gui, checked)
 end
 
 --TODO: Rewrite this and simplify it
-function BAR:SetVisibility(msg)
+function Bar:SetVisibility(msg)
 	wipe(statetable)
 	local toggle, index, num = (" "):split(msg)
 	toggle = toggle:lower()
@@ -1757,7 +1757,7 @@ function BAR:SetVisibility(msg)
 end
 
 
-function BAR:SetAutoHide(checked)
+function Bar:SetAutoHide(checked)
 	if checked then
 		self.data.autoHide = true
 	else
@@ -1768,11 +1768,11 @@ function BAR:SetAutoHide(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetAutoHide()
+function Bar:GetAutoHide()
 	return self.data.autoHide
 end
 
-function BAR:SetShowGrid(checked)
+function Bar:SetShowGrid(checked)
 	if checked then
 		self.data.showGrid = true
 	else
@@ -1783,11 +1783,11 @@ function BAR:SetShowGrid(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetShowGrid()
+function Bar:GetShowGrid()
 	return self.data.showGrid
 end
 
-function BAR:SetSpellGlow(option)
+function Bar:SetSpellGlow(option)
 	if option then
 		if option == "default" then
 			self.data.spellGlow = "default"
@@ -1803,12 +1803,12 @@ function BAR:SetSpellGlow(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetSpellGlow()
+function Bar:GetSpellGlow()
 	return self.data.spellGlow
 end
 
 
-function BAR:SetSnapTo(checked)
+function Bar:SetSnapTo(checked)
 	if checked then
 		self.data.snapTo = true
 	else
@@ -1830,12 +1830,12 @@ function BAR:SetSnapTo(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetSnapTo()
+function Bar:GetSnapTo()
 	return self.data.snapTo
 end
 
 
-function BAR:SetClickMode(mode)
+function Bar:SetClickMode(mode)
 	if mode then
 		self.data.clickMode = mode
 	else
@@ -1846,12 +1846,12 @@ function BAR:SetClickMode(mode)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetClickMode()
+function Bar:GetClickMode()
 	return self.data.clickMode
 end
 
 
-function BAR:SetMultiSpec(checked)
+function Bar:SetMultiSpec(checked)
 	if checked then
 		self.data.multiSpec = true
 	else
@@ -1865,12 +1865,12 @@ function BAR:SetMultiSpec(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetMultiSpec()
+function Bar:GetMultiSpec()
 	return self.data.multiSpec
 end
 
 
-function BAR:SetBarConceal(checked)
+function Bar:SetBarConceal(checked)
 	if checked then
 		self.data.conceal = true
 		self:SetBackdropColor(1,0,0,0.4)
@@ -1882,11 +1882,11 @@ function BAR:SetBarConceal(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetBarConceal()
+function Bar:GetBarConceal()
 	return self.data.conceal
 end
 
-function BAR:SetBarLock(option)
+function Bar:SetBarLock(option)
 	if option then
 		if option == "shift" then
 			self.data.barLock = "shift"
@@ -1904,12 +1904,12 @@ function BAR:SetBarLock(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetBarLock()
+function Bar:GetBarLock()
 	return self.data.barLock
 end
 
 
-function BAR:SetTooltipOption(option)
+function Bar:SetTooltipOption(option)
 	if option then
 		if option == "minimal" then
 			self.data.tooltips = "minimal"
@@ -1925,11 +1925,11 @@ function BAR:SetTooltipOption(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetTooltipOption()
+function Bar:GetTooltipOption()
 	return self.data.tooltips
 end
 
-function BAR:SetTooltipCombat(checked)
+function Bar:SetTooltipCombat(checked)
 	if checked then
 		self.data.tooltipsCombat = true
 	else
@@ -1939,11 +1939,11 @@ function BAR:SetTooltipCombat(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetTooltipCombat()
+function Bar:GetTooltipCombat()
 	return self.data.tooltipsCombat
 end
 
-function BAR:SetBarShape(option)
+function Bar:SetBarShape(option)
 	if option then
 		if option == "linear" or option == "circle" or option == "circle + one" then
 			self.data.shape = option
@@ -1960,11 +1960,11 @@ function BAR:SetBarShape(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetBarShape()
+function Bar:GetBarShape()
 	return self.data.shape
 end
 
-function BAR:SetColumns(option)
+function Bar:SetColumns(option)
 	if option then
 		if option > 0 then
 			self.data.columns = option
@@ -1981,11 +1981,11 @@ function BAR:SetColumns(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetColumns()
+function Bar:GetColumns()
 	return self.data.columns
 end
 
-function BAR:SetArcStart(option)
+function Bar:SetArcStart(option)
 	if option then
 		self.data.arcStart = option
 	else
@@ -1998,11 +1998,11 @@ function BAR:SetArcStart(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetArcStart()
+function Bar:GetArcStart()
 	return self.data.arcStart
 end
 
-function BAR:SetArcLength(option)
+function Bar:SetArcLength(option)
 	if option then
 		self.data.arcLength = option
 	else
@@ -2015,13 +2015,13 @@ function BAR:SetArcLength(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetArcLength()
+function Bar:GetArcLength()
 	return self.data.arcLength
 end
 
 
 
-function BAR:SetHorizontalPad(option)
+function Bar:SetHorizontalPad(option)
 	if option then
 		self.data.padH = option
 	else
@@ -2034,11 +2034,11 @@ function BAR:SetHorizontalPad(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetHorizontalPad()
+function Bar:GetHorizontalPad()
 	return self.data.padH
 end
 
-function BAR:SetVerticalPad(option)
+function Bar:SetVerticalPad(option)
 	if option then
 		self.data.padV = option
 	else
@@ -2051,12 +2051,12 @@ function BAR:SetVerticalPad(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetVerticalPad()
+function Bar:GetVerticalPad()
 	return self.data.padV
 end
 
 
-function BAR:SetBarScale(option)
+function Bar:SetBarScale(option)
 	if option then
 		self.data.scale = option
 	else
@@ -2069,11 +2069,11 @@ function BAR:SetBarScale(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetBarScale()
+function Bar:GetBarScale()
 	return self.data.scale
 end
 
-function BAR:SetStrata(option)
+function Bar:SetStrata(option)
 	--option should be numeric, and should not ever be lower than 2. In the GUI we should make sure the list starts at 2 and runs until 6
 	if option and option >=2 and option <= 6 then
 		self.data.strata = option
@@ -2086,11 +2086,11 @@ function BAR:SetStrata(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetStrata()
+function Bar:GetStrata()
 	return self.data.strata
 end
 
-function BAR:SetBarAlpha(option)
+function Bar:SetBarAlpha(option)
 	if option then
 		self.data.alpha = option
 	else
@@ -2101,11 +2101,11 @@ function BAR:SetBarAlpha(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetBarAlpha()
+function Bar:GetBarAlpha()
 	return self.data.alpha
 end
 
-function BAR:SetAlphaUp(option)
+function Bar:SetAlphaUp(option)
 	if option then
 		if option == "off" or option == "mouseover" or option == "combat" or option =="combat + mouseover" then
 			self.data.alphaUp = option
@@ -2120,12 +2120,12 @@ function BAR:SetAlphaUp(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetAlphaUp()
+function Bar:GetAlphaUp()
 	--TODO: Get rid of :lower() in the future
 	return self.data.alphaUp:lower() --shouldn't have to set lower but older databases might have some capital letters
 end
 
-function BAR:SetAlphaUpSpeed(option)
+function Bar:SetAlphaUpSpeed(option)
 	if option then
 		if option < 0.01 then
 			self.data.fadeSpeed = 0.01
@@ -2141,11 +2141,11 @@ function BAR:SetAlphaUpSpeed(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetAlphaUpSpeed()
+function Bar:GetAlphaUpSpeed()
 	return self.data.fadeSpeed
 end
 
-function BAR:SetXAxis(option)
+function Bar:SetXAxis(option)
 	if option then
 		self.data.x = option
 	else
@@ -2156,11 +2156,11 @@ function BAR:SetXAxis(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetXAxis()
+function Bar:GetXAxis()
 	return self.data.x
 end
 
-function BAR:SetYAxis(option)
+function Bar:SetYAxis(option)
 	if option then
 		self.data.y = option
 	else
@@ -2171,11 +2171,11 @@ function BAR:SetYAxis(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetYAxis()
+function Bar:GetYAxis()
 	return self.data.y
 end
 
-function BAR:SetShowBindText(checked)
+function Bar:SetShowBindText(checked)
 	if checked then
 		self.data.bindText = true
 	else
@@ -2186,11 +2186,11 @@ function BAR:SetShowBindText(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetShowBindText()
+function Bar:GetShowBindText()
 	return self.data.bindText
 end
 
-function BAR:SetBindColor(option)
+function Bar:SetBindColor(option)
 	if option then
 		self.data.bindColor = option
 	else
@@ -2201,11 +2201,11 @@ function BAR:SetBindColor(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetBindColor()
+function Bar:GetBindColor()
 	return self.data.bindColor
 end
 
-function BAR:SetShowButtonText(checked)
+function Bar:SetShowButtonText(checked)
 	if checked then
 		self.data.buttonText = true
 	else
@@ -2216,11 +2216,11 @@ function BAR:SetShowButtonText(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetShowButtonText()
+function Bar:GetShowButtonText()
 	return self.data.buttonText
 end
 
-function BAR:SetMacroColor(option)
+function Bar:SetMacroColor(option)
 	if option then
 		self.data.macroColor = option
 	else
@@ -2231,11 +2231,11 @@ function BAR:SetMacroColor(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetMacroColor()
+function Bar:GetMacroColor()
 	return self.data.macroColor
 end
 
-function BAR:SetShowCountText(checked)
+function Bar:SetShowCountText(checked)
 	if checked then
 		self.data.countText = true
 	else
@@ -2246,11 +2246,11 @@ function BAR:SetShowCountText(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetShowCountText()
+function Bar:GetShowCountText()
 	return self.data.countText
 end
 
-function BAR:SetCountColor(option)
+function Bar:SetCountColor(option)
 	if option then
 		self.data.countColor = option
 	else
@@ -2261,11 +2261,11 @@ function BAR:SetCountColor(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetCountColor()
+function Bar:GetCountColor()
 	return self.data.countColor
 end
 
-function BAR:SetShowRangeIndicator(checked)
+function Bar:SetShowRangeIndicator(checked)
 	if checked then
 		self.data.rangeInd = true
 	else
@@ -2276,11 +2276,11 @@ function BAR:SetShowRangeIndicator(checked)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetShowRangeIndicator()
+function Bar:GetShowRangeIndicator()
 	return self.data.rangeInd
 end
 
-function BAR:SetRangeColor(option)
+function Bar:SetRangeColor(option)
 	if option then
 		self.data.rangecolor = option
 	else
@@ -2291,11 +2291,11 @@ function BAR:SetRangeColor(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetRangeColor()
+function Bar:GetRangeColor()
 	return self.data.rangecolor
 end
 
-function BAR:SetShowCooldownText(checked)
+function Bar:SetShowCooldownText(checked)
 	if checked then
 		self.data.cdText = true
 	else
@@ -2305,11 +2305,11 @@ function BAR:SetShowCooldownText(checked)
 	self:UpdateObjectCooldowns()
 end
 
-function BAR:GetShowCooldownText()
+function Bar:GetShowCooldownText()
 	return self.data.cdText
 end
 
-function BAR:SetCooldownColor1(option)
+function Bar:SetCooldownColor1(option)
 	if option then
 		self.data.cdcolor1 = option
 	else
@@ -2319,11 +2319,11 @@ function BAR:SetCooldownColor1(option)
 	self:UpdateObjectCooldowns()
 end
 
-function BAR:GetCooldownColor1()
+function Bar:GetCooldownColor1()
 	return self.data.cdcolor1
 end
 
-function BAR:SetCooldownColor2(option)
+function Bar:SetCooldownColor2(option)
 	if option then
 		self.data.cdcolor2 = option
 	else
@@ -2333,11 +2333,11 @@ function BAR:SetCooldownColor2(option)
 	self:UpdateObjectCooldowns()
 end
 
-function BAR:GetCooldownColor2()
+function Bar:GetCooldownColor2()
 	return self.data.cdcolor2
 end
 
-function BAR:SetShowCooldownAlpha(checked)
+function Bar:SetShowCooldownAlpha(checked)
 	if checked then
 		self.data.cdAlpha = true --hardcoded for now, maybe one day add an option to configure this value
 	else
@@ -2347,11 +2347,11 @@ function BAR:SetShowCooldownAlpha(checked)
 	self:UpdateObjectCooldowns()
 end
 
-function BAR:GetShowCooldownAlpha()
+function Bar:GetShowCooldownAlpha()
 	return self.data.cdAlpha
 end
 
-function BAR:SetShowBorderStyle(checked)
+function Bar:SetShowBorderStyle(checked)
 	if checked then
 		self.data.showBorderStyle = true
 	else
@@ -2361,11 +2361,11 @@ function BAR:SetShowBorderStyle(checked)
 	self:UpdateObjectIcons()
 end
 
-function BAR:GetShowBorderStyle()
+function Bar:GetShowBorderStyle()
 	return self.data.showBorderStyle
 end
 
-function BAR:SetManaColor(option)
+function Bar:SetManaColor(option)
 	if option then
 		self.data.manacolor = option
 	else
@@ -2376,6 +2376,6 @@ function BAR:SetManaColor(option)
 	self:UpdateBarStatus()
 end
 
-function BAR:GetManaColor()
+function Bar:GetManaColor()
 	return self.data.manacolor
 end

--- a/Objects/BAR_SnapTo.lua
+++ b/Objects/BAR_SnapTo.lua
@@ -6,7 +6,7 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
-local BAR = Neuron.BAR
+local Bar = Neuron.Bar
 
 local function frameIsDependentOnFrame(frame, otherFrame)
 
@@ -119,7 +119,7 @@ end
 --[[ Usable Functions ]]--
 
 
-function BAR:StickToEdge()
+function Bar:StickToEdge()
 
 	local point, x, y= self:GetPosition()
 	local changed
@@ -155,7 +155,7 @@ function BAR:StickToEdge()
 	end
 end
 
-function BAR:Stick(oFrame, tolerance, xOff, yOff)
+function Bar:Stick(oFrame, tolerance, xOff, yOff)
 
 	xOff, yOff = xOff or 0, yOff or 0
 
@@ -217,7 +217,7 @@ function BAR:Stick(oFrame, tolerance, xOff, yOff)
 	end
 end
 
-function BAR:StickToPoint(oFrame, point, xOff, yOff)
+function Bar:StickToPoint(oFrame, point, xOff, yOff)
 
 	xOff, yOff = xOff or 0, yOff or 0
 

--- a/Objects/BagButton.lua
+++ b/Objects/BagButton.lua
@@ -6,9 +6,9 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class BAGBTN : BUTTON @class BAGBTN inherits from class BUTTON
-local BAGBTN = setmetatable({}, {__index = Neuron.BUTTON})
-Neuron.BAGBTN = BAGBTN
+---@class BagButton : Button @class BagButton inherits from class Button
+local BagButton = setmetatable({}, {__index = Neuron.Button})
+Neuron.BagButton = BagButton
 
 Neuron.NUM_BAG_BUTTONS = 6
 
@@ -24,14 +24,14 @@ local blizzBagButtons = {
 
 ---------------------------------------------------------
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return BAGBTN @ A newly created BAGBTN object
-function BAGBTN.new(bar, buttonID, defaults)
+---@return BagButton @ A newly created BagButton object
+function BagButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.BUTTON.new(bar, buttonID, BAGBTN, "BagBar", "BagButton", "NeuronAnchorButtonTemplate")
+	local newButton = Neuron.Button.new(bar, buttonID, BagButton, "BagBar", "BagButton", "NeuronAnchorButtonTemplate")
 
 	if defaults then
 		newButton:SetDefaults(defaults)
@@ -42,7 +42,7 @@ end
 
 --------------------------------------------------------
 
-function BAGBTN:InitializeButton()
+function BagButton:InitializeButton()
 	if blizzBagButtons[self.id] then
 		self.hookedButton = blizzBagButtons[self.id]
 		self.hookedButton:ClearAllPoints()
@@ -58,7 +58,7 @@ function BAGBTN:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function BAGBTN:InitializeButtonSettings()
+function BagButton:InitializeButtonSettings()
 	self:SetFrameStrata(Neuron.STRATAS[self.bar:GetStrata()-1])
 	self:SetScale(self.bar:GetBarScale())
 	self:SetSkinned()
@@ -66,7 +66,7 @@ function BAGBTN:InitializeButtonSettings()
 end
 
 ---simplified SetSkinned for the Bag Buttons. They're unique in that they contain buttons inside of the buttons
---[[function BAGBTN:SetSkinned()
+--[[function BagButton:SetSkinned()
 	local SKIN = LibStub("Masque", true)
 	if SKIN then
 		local btnData = {
@@ -87,27 +87,27 @@ end]]
 --------------------- Overrides ---------------------
 -----------------------------------------------------
 
---overwrite function in parent class BUTTON
-function BAGBTN:UpdateStatus()
+--overwrite function in parent class Button
+function BagButton:UpdateStatus()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function BAGBTN:UpdateIcon()
+--overwrite function in parent class Button
+function BagButton:UpdateIcon()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function BAGBTN:UpdateUsable()
+--overwrite function in parent class Button
+function BagButton:UpdateUsable()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function BAGBTN:UpdateCount()
+--overwrite function in parent class Button
+function BagButton:UpdateCount()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function BAGBTN:UpdateCooldown()
+--overwrite function in parent class Button
+function BagButton:UpdateCooldown()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function BAGBTN:UpdateTooltip()
+--overwrite function in parent class Button
+function BagButton:UpdateTooltip()
 	-- empty --
 end

--- a/Objects/Button.lua
+++ b/Objects/Button.lua
@@ -6,28 +6,28 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class BUTTON : CheckButton @define BUTTON as inheriting from CheckButton
-local BUTTON = setmetatable({}, {__index = CreateFrame("CheckButton")}) --this is the metatable for our button object
-Neuron.BUTTON = BUTTON
+---@class Button : CheckButton @define Button as inheriting from CheckButton
+local Button = setmetatable({}, {__index = CreateFrame("CheckButton")}) --this is the metatable for our button object
+Neuron.Button = Button
 
 local SKIN = LibStub("Masque", true)
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
-LibStub("AceBucket-3.0"):Embed(BUTTON)
-LibStub("AceEvent-3.0"):Embed(BUTTON)
-LibStub("AceTimer-3.0"):Embed(BUTTON)
-LibStub("AceHook-3.0"):Embed(BUTTON)
+LibStub("AceBucket-3.0"):Embed(Button)
+LibStub("AceEvent-3.0"):Embed(Button)
+LibStub("AceTimer-3.0"):Embed(Button)
+LibStub("AceHook-3.0"):Embed(Button)
 
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
----@param baseObj BUTTON @Base object class for this specific button
+---@param baseObj Button @Base object class for this specific button
 ---@param barClass string @Class type for the bar the button will be on
 ---@param objType string @Type of object this button will be
 ---@param template string @The template name that this frame will derive from
----@return BUTTON @ A newly created BUTTON object
-function BUTTON.new(bar, buttonID, baseObj, barClass, objType, template)
+---@return Button @ A newly created Button object
+function Button.new(bar, buttonID, baseObj, barClass, objType, template)
 	local newButton
 	local newButtonName = bar:GetName().."_"..objType..buttonID
 
@@ -64,7 +64,7 @@ end
 ---These will often be overwritten per bar type--
 ------------------------------------------------
 
-function BUTTON.ChangeSelectedButton(newButton)
+function Button.ChangeSelectedButton(newButton)
 	if newButton and newButton ~= Neuron.currentButton then
 		if Neuron.currentButton and Neuron.currentButton.bar ~= newButton.bar then
 			local bar = Neuron.currentButton.bar
@@ -101,7 +101,7 @@ function BUTTON.ChangeSelectedButton(newButton)
 	end
 end
 
-function BUTTON:CancelCooldownTimer(stopAnimation)
+function Button:CancelCooldownTimer(stopAnimation)
 	--cleanup so on state changes the cooldowns don't persist
 	if self:TimeLeft(self.Cooldown.cooldownTimer) ~= 0 then
 		self:CancelTimer(self.Cooldown.cooldownTimer)
@@ -124,7 +124,7 @@ function BUTTON:CancelCooldownTimer(stopAnimation)
 	self:UpdateVisibility()
 end
 
-function BUTTON:SetCooldownTimer(start, duration, enable, modrate, showCountdownTimer, color1, color2, showCountdownAlpha, charges, maxCharges)
+function Button:SetCooldownTimer(start, duration, enable, modrate, showCountdownTimer, color1, color2, showCountdownAlpha, charges, maxCharges)
 	if not self.isShown then --if the button isn't shown, don't do set any cooldowns
 		--if there's currently a timer, cancel it
 		self:CancelCooldownTimer(true)
@@ -198,7 +198,7 @@ end
 
 ---this function is called by a repeating timer set in SetCooldownTimer every 0.2sec, which is autoGmatically is set to terminate 1sec after the cooldown timer ends
 ---this function's job is to overlay the countdown text on a button and set the button's cooldown alpha
-function BUTTON:CooldownCounterUpdate()
+function Button:CooldownCounterUpdate()
 	local coolDown, formatted, size
 
 	local normalcolor = self.Cooldown.normalcolor
@@ -277,7 +277,7 @@ function BUTTON:CooldownCounterUpdate()
 	end
 end
 
-function BUTTON:LoadDataFromDatabase(curSpec, curState)
+function Button:LoadDataFromDatabase(curSpec, curState)
 	self.config = self.DB.config
 	self.keys = self.DB.keys
 
@@ -294,7 +294,7 @@ function BUTTON:LoadDataFromDatabase(curSpec, curState)
 	end
 end
 
-function BUTTON:SetDefaults(defaults)
+function Button:SetDefaults(defaults)
 	if not defaults then
 		return
 	end
@@ -312,7 +312,7 @@ function BUTTON:SetDefaults(defaults)
 	end
 end
 
-function BUTTON:SetSkinned(flyout)
+function Button:SetSkinned(flyout)
 	if SKIN then
 		local btnData = {
 			Normal = self.Normal,
@@ -337,7 +337,7 @@ function BUTTON:SetSkinned(flyout)
 	end
 end
 
-function BUTTON:HasAction()
+function Button:HasAction()
 	if self.actionID then
 		if self.actionID == 0 then
 			return true
@@ -358,7 +358,7 @@ end
 ------------------------------------- Update Functions ----------------------------------
 -----------------------------------------------------------------------------------------
 
-function BUTTON:UpdateAll()
+function Button:UpdateAll()
 	self:UpdateData()
 	self:UpdateIcon()
 	self:UpdateStatus()
@@ -366,11 +366,11 @@ function BUTTON:UpdateAll()
 	self:UpdateUsable()
 end
 
-function BUTTON:UpdateData()
+function Button:UpdateData()
 	-- empty --
 end
 
-function BUTTON:UpdateNormalTexture()
+function Button:UpdateNormalTexture()
 	local actionTexture, noactionTexture
 
 	if self.__MSQ_NormalSkin then
@@ -390,7 +390,7 @@ function BUTTON:UpdateNormalTexture()
 	end
 end
 
-function BUTTON:UpdateVisibility()
+function Button:UpdateVisibility()
 	if self.isShown or Neuron.barEditMode or (Neuron.buttonEditMode and self.editFrame) or (Neuron.bindingMode and self.keybindFrame) then
 		self.isShown = true
 	else
@@ -408,7 +408,7 @@ end
 ------------------------------------- Set Count/Charge ----------------------------------
 -----------------------------------------------------------------------------------------
 
-function BUTTON:UpdateCount()
+function Button:UpdateCount()
 	if self.actionID then
 		self:UpdateActionCount()
 	elseif self.spell then
@@ -422,7 +422,7 @@ end
 
 
 ---Updates the buttons "count", i.e. the spell charges
-function BUTTON:UpdateSpellCount()
+function Button:UpdateSpellCount()
 	local charges, maxCharges = GetSpellCharges(self.spell)
 	local count = GetSpellCount(self.spell)
 
@@ -437,7 +437,7 @@ end
 
 
 ---Updates the buttons "count", i.e. the item stack size
-function BUTTON:UpdateItemCount()
+function Button:UpdateItemCount()
 	local count = GetItemCount(self.item,nil,true)
 
 	if count and count > 1 then
@@ -448,7 +448,7 @@ function BUTTON:UpdateItemCount()
 end
 
 
-function BUTTON:UpdateActionCount()
+function Button:UpdateActionCount()
 	local count = GetActionCount(self.actionID)
 
 	if count and count > 0 then
@@ -462,7 +462,7 @@ end
 ------------------------------------- Set Cooldown --------------------------------------
 -----------------------------------------------------------------------------------------
 
-function BUTTON:UpdateCooldown()
+function Button:UpdateCooldown()
 	if self.actionID then
 		self:UpdateActionCooldown()
 	elseif self.spell then
@@ -475,7 +475,7 @@ function BUTTON:UpdateCooldown()
 	end
 end
 
-function BUTTON:UpdateSpellCooldown()
+function Button:UpdateSpellCooldown()
 	if self.spell and self.isShown then
 		local start, duration, enable, modrate = GetSpellCooldown(self.spell)
 		local charges, maxCharges, chStart, chDuration, chargemodrate = GetSpellCharges(self.spell)
@@ -490,7 +490,7 @@ function BUTTON:UpdateSpellCooldown()
 	end
 end
 
-function BUTTON:UpdateItemCooldown()
+function Button:UpdateItemCooldown()
 	if self.item and self.isShown then
 		local start, duration, enable, modrate
 		if Neuron.itemCache[self.item:lower()] then
@@ -505,7 +505,7 @@ function BUTTON:UpdateItemCooldown()
 	end
 end
 
-function BUTTON:UpdateActionCooldown()
+function Button:UpdateActionCooldown()
 	if self.actionID and self.isShown then
 		if HasAction(self.actionID) then
 			local start, duration, enable, modrate = GetActionCooldown(self.actionID)
@@ -520,7 +520,7 @@ end
 ------------------------------------- Set Usable ----------------------------------------
 -----------------------------------------------------------------------------------------
 
-function BUTTON:UpdateUsable()
+function Button:UpdateUsable()
 	if Neuron.buttonEditMode or Neuron.bindingMode then
 		self.Icon:SetVertexColor(0.2, 0.2, 0.2)
 	elseif self.actionID then
@@ -534,7 +534,7 @@ function BUTTON:UpdateUsable()
 	end
 end
 
-function BUTTON:UpdateUsableSpell()
+function Button:UpdateUsableSpell()
 	local isUsable, notEnoughMana = IsUsableSpell(self.spell)
 
 	if notEnoughMana and self.bar:GetManaColor() then
@@ -554,7 +554,7 @@ function BUTTON:UpdateUsableSpell()
 	end
 end
 
-function BUTTON:UpdateUsableItem()
+function Button:UpdateUsableItem()
 	local isUsable, notEnoughMana = IsUsableItem(self.item)
 
 	--for some reason toys don't show as usable items, so this is a workaround for that
@@ -580,7 +580,7 @@ function BUTTON:UpdateUsableItem()
 	end
 end
 
-function BUTTON:UpdateUsableAction()
+function Button:UpdateUsableAction()
 	if self.actionID == 0 then
 		self.Icon:SetVertexColor(1.0, 1.0, 1.0)
 		return
@@ -605,7 +605,7 @@ end
 -------------------------------------- Set Icon -----------------------------------------
 -----------------------------------------------------------------------------------------
 
-function BUTTON:UpdateIcon()
+function Button:UpdateIcon()
 	if self.actionID then
 		self:UpdateActionIcon()
 	elseif self.spell then
@@ -627,7 +627,7 @@ function BUTTON:UpdateIcon()
 	self:UpdateNormalTexture()
 end
 
-function BUTTON:UpdateSpellIcon()
+function Button:UpdateSpellIcon()
 	local texture = GetSpellTexture(self.spell)
 
 	if not texture then
@@ -649,7 +649,7 @@ function BUTTON:UpdateSpellIcon()
 	self.Border:Hide()
 end
 
-function BUTTON:UpdateItemIcon()
+function Button:UpdateItemIcon()
 	local texture = GetItemIcon(self.item)
 
 	if not texture then
@@ -674,7 +674,7 @@ function BUTTON:UpdateItemIcon()
 	end
 end
 
-function BUTTON:UpdateActionIcon()
+function Button:UpdateActionIcon()
 	local texture
 
 	if HasAction(self.actionID) then
@@ -695,7 +695,7 @@ end
 -------------------------------------- Set Status ---------------------------------------
 -----------------------------------------------------------------------------------------
 
-function BUTTON:UpdateStatus()
+function Button:UpdateStatus()
 	if self.actionID then
 		self:UpdateActionStatus()
 	elseif self:GetMacroEquipmentSet() then
@@ -714,7 +714,7 @@ function BUTTON:UpdateStatus()
 	end
 end
 
-function BUTTON:UpdateSpellStatus()
+function Button:UpdateSpellStatus()
 	if IsCurrentSpell(self.spell) or IsAutoRepeatSpell(self.spell) then
 		self:SetChecked(true)
 	else
@@ -726,7 +726,7 @@ function BUTTON:UpdateSpellStatus()
 	self:UpdateUsable()
 end
 
-function BUTTON:UpdateItemStatus()
+function Button:UpdateItemStatus()
 	if IsCurrentItem(self.item) then
 		self:SetChecked(true)
 	else
@@ -738,7 +738,7 @@ function BUTTON:UpdateItemStatus()
 	self:UpdateUsable()
 end
 
-function BUTTON:UpdateActionStatus()
+function Button:UpdateActionStatus()
 	local name
 
 	if self.actionID then
@@ -772,7 +772,7 @@ end
 ------------------------------------- Set Tooltip ---------------------------------------
 -----------------------------------------------------------------------------------------
 
-function BUTTON:UpdateTooltip()
+function Button:UpdateTooltip()
 	if self.bar:GetTooltipOption() ~= "off" then --if the bar isn't showing tooltips, don't proceed
 
 		--if we are in combat and we don't have tooltips enable in-combat, don't go any further
@@ -802,7 +802,7 @@ function BUTTON:UpdateTooltip()
 	end
 end
 
-function BUTTON:UpdateSpellTooltip()
+function Button:UpdateSpellTooltip()
 	if self.spell and self.spellID then --try to get the correct spell from the spellbook first
 		if self.bar:GetTooltipOption() == "normal" then
 			GameTooltip:SetSpellByID(self.spellID)
@@ -822,7 +822,7 @@ end
 
 -- note that using SetHyperlink to set the tooltip to the same value
 -- twice will close the tooltip. see issue brittyazel/Neuron#354
-function BUTTON:UpdateItemTooltip()
+function Button:UpdateItemTooltip()
 	local name, link = GetItemInfo(self.item)
 	name = name or Neuron.itemCache[self.item:lower()]
 	link = link or "item:"..name..":0:0:0:0:0:0:0"
@@ -838,7 +838,7 @@ function BUTTON:UpdateItemTooltip()
 	end
 end
 
-function BUTTON:UpdateActionTooltip()
+function Button:UpdateActionTooltip()
 	if HasAction(self.actionID) then
 		if self.bar:GetTooltipOption() == "normal" or self.bar:GetTooltipOption() == "minimal" then
 			GameTooltip:SetAction(self.actionID)
@@ -852,7 +852,7 @@ end
 -----------------------------------------------------
 
 --Macro Icon
-function BUTTON:SetMacroIcon(newIcon)
+function Button:SetMacroIcon(newIcon)
 	if newIcon then
 		self.data.macro_Icon = newIcon
 	else
@@ -860,13 +860,13 @@ function BUTTON:SetMacroIcon(newIcon)
 	end
 end
 
-function BUTTON:GetMacroIcon()
+function Button:GetMacroIcon()
 	return self.data.macro_Icon
 end
 
 
 --Macro Text
-function BUTTON:SetMacroText(newText)
+function Button:SetMacroText(newText)
 	if newText then
 		self.data.macro_Text = newText
 	else
@@ -874,13 +874,13 @@ function BUTTON:SetMacroText(newText)
 	end
 end
 
-function BUTTON:GetMacroText()
+function Button:GetMacroText()
 	return self.data.macro_Text
 end
 
 
 --Macro Name
-function BUTTON:SetMacroName(newName)
+function Button:SetMacroName(newName)
 	if newName then
 		self.data.macro_Name = newName
 	else
@@ -888,13 +888,13 @@ function BUTTON:SetMacroName(newName)
 	end
 end
 
-function BUTTON:GetMacroName()
+function Button:GetMacroName()
 	return self.data.macro_Name
 end
 
 
 --Macro Note
-function BUTTON:SetMacroNote(newNote)
+function Button:SetMacroNote(newNote)
 	if newNote then
 		self.data.macro_Note = newNote
 	else
@@ -902,13 +902,13 @@ function BUTTON:SetMacroNote(newNote)
 	end
 end
 
-function BUTTON:GetMacroNote()
+function Button:GetMacroNote()
 	return self.data.macro_Note
 end
 
 
 --Macro Use Note
-function BUTTON:SetMacroUseNote(newUseNote)
+function Button:SetMacroUseNote(newUseNote)
 	if newUseNote then
 		self.data.macro_UseNote = newUseNote
 	else
@@ -916,13 +916,13 @@ function BUTTON:SetMacroUseNote(newUseNote)
 	end
 end
 
-function BUTTON:GetMacroUseNote()
+function Button:GetMacroUseNote()
 	return self.data.macro_UseNote
 end
 
 
 --Macro Blizz Macro
-function BUTTON:SetMacroBlizzMacro(newBlizzMacro)
+function Button:SetMacroBlizzMacro(newBlizzMacro)
 	if newBlizzMacro then
 		self.data.macro_BlizzMacro = newBlizzMacro
 	else
@@ -930,13 +930,13 @@ function BUTTON:SetMacroBlizzMacro(newBlizzMacro)
 	end
 end
 
-function BUTTON:GetMacroBlizzMacro()
+function Button:GetMacroBlizzMacro()
 	return self.data.macro_BlizzMacro
 end
 
 
 --Macro EquipmentSet
-function BUTTON:SetMacroEquipmentSet(newEquipmentSet)
+function Button:SetMacroEquipmentSet(newEquipmentSet)
 	if newEquipmentSet then
 		self.data.macro_EquipmentSet = newEquipmentSet
 	else
@@ -944,6 +944,6 @@ function BUTTON:SetMacroEquipmentSet(newEquipmentSet)
 	end
 end
 
-function BUTTON:GetMacroEquipmentSet()
+function Button:GetMacroEquipmentSet()
 	return self.data.macro_EquipmentSet
 end

--- a/Objects/Button_EditorOverlay.lua
+++ b/Objects/Button_EditorOverlay.lua
@@ -7,10 +7,10 @@ local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
 
----The functions in this file are part of the ACTIONBUTTON class.
+---The functions in this file are part of the ActionButton class.
 ---It was just easier to put them all in their own file for organization.
 
-local BUTTON = Neuron.BUTTON
+local Button = Neuron.Button
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
@@ -19,7 +19,7 @@ local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 --------------------------Button Editor Overlay-----------------------------
 ----------------------------------------------------------------------------
 
-function BUTTON:EditorOverlay_CreateEditFrame()
+function Button:EditorOverlay_CreateEditFrame()
 	local editFrame = CreateFrame("Button", self:GetName().."EditFrame", self, "NeuronOverlayFrameTemplate")
 	setmetatable(editFrame, { __index = CreateFrame("Button") })
 
@@ -33,7 +33,7 @@ function BUTTON:EditorOverlay_CreateEditFrame()
 
 	editFrame.label:SetText(L["Edit"])
 
-	if self.objType == "ACTIONBUTTON" then
+	if self.objType == "ActionButton" then
 		editFrame.select.Left:SetTexture("")
 		editFrame.select.Right:SetTexture("")
 	else
@@ -59,24 +59,24 @@ function BUTTON:EditorOverlay_CreateEditFrame()
 	editFrame:Hide()
 end
 
-function BUTTON:EditorOverlay_OnShow()
+function Button:EditorOverlay_OnShow()
 end
 
-function BUTTON:EditorOverlay_OnEnter()
+function Button:EditorOverlay_OnEnter()
 	self.editFrame.select:Show()
 	GameTooltip:SetOwner(self.editFrame, "ANCHOR_RIGHT")
 	GameTooltip:Show()
 end
 
-function BUTTON:EditorOverlay_OnLeave()
+function Button:EditorOverlay_OnLeave()
 	if self ~= Neuron.currentButton then
 		self.editFrame.select:Hide()
 	end
 	GameTooltip:Hide()
 end
 
-function BUTTON:EditorOverlay_OnClick()
-	Neuron.BUTTON.ChangeSelectedButton(self)
+function Button:EditorOverlay_OnClick()
+	Neuron.Button.ChangeSelectedButton(self)
 	if addonTable.NeuronEditor then
 		Neuron.NeuronGUI:RefreshEditor()
 	end

--- a/Objects/Button_KeybindOverlay.lua
+++ b/Objects/Button_KeybindOverlay.lua
@@ -6,7 +6,7 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
-local BUTTON = Neuron.BUTTON
+local Button = Neuron.Button
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
@@ -15,9 +15,9 @@ local NEURON_VIRTUAL_KEY = "Hotkey"
 
 ----------------------------------------------------------
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@return BUTTON @ A newly created BUTTON object
-function BUTTON:KeybindOverlay_CreateEditFrame()
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@return Button @ A newly created Button object
+function Button:KeybindOverlay_CreateEditFrame()
 	local keybindFrame = CreateFrame("Button", self:GetName().."BindFrame", self, "NeuronOverlayFrameTemplate")
 	setmetatable(keybindFrame, { __index = CreateFrame("Button") })
 
@@ -108,7 +108,7 @@ end
 
 --- Returns the keybind for a given button
 --- @return string @The current key that is bound to the selected button
-function BUTTON:KeybindOverlay_GetBindKeyList()
+function Button:KeybindOverlay_GetBindKeyList()
 	if not self.data then
 		return L["None"]
 	end
@@ -127,7 +127,7 @@ end
 
 --- Clears the bindings of a given button
 --- @param key string @Which key was pressed
-function BUTTON:KeybindOverlay_ClearBindings(key)
+function Button:KeybindOverlay_ClearBindings(key)
 	if key then
 		local newkey = key:gsub("%-", "%%-")
 		self.keys.hotKeys = self.keys.hotKeys:gsub(newkey..":", "")
@@ -144,7 +144,7 @@ function BUTTON:KeybindOverlay_ClearBindings(key)
 end
 
 --- Applies binding to button
-function BUTTON:KeybindOverlay_ApplyBindings()
+function Button:KeybindOverlay_ApplyBindings()
 	local virtualKey
 
 	---checks if the button is a Neuron action or a special Blizzard action (such as a zone ability)
@@ -176,7 +176,7 @@ end
 
 --- Processes the change to a key bind
 --- @param key string @The key to be used
-function BUTTON:KeybindOverlay_ProcessBinding(key)
+function Button:KeybindOverlay_ProcessBinding(key)
 	--if the button is locked, warn the user as to the locked status
 	if self.keys and self.keys.hotKeyLock then
 		UIErrorsFrame:AddMessage(L["Bindings_Locked_Notice"], 1.0, 1.0, 1.0, 1.0, UIERRORS_HOLD_TIME)
@@ -231,7 +231,7 @@ function BUTTON:KeybindOverlay_ProcessBinding(key)
 end
 
 --- OnShow Event handler
-function BUTTON:KeybindOverlay_OnShow()
+function Button:KeybindOverlay_OnShow()
 	local priority = ""
 
 	if self.keys.hotKeyPri then
@@ -244,7 +244,7 @@ function BUTTON:KeybindOverlay_OnShow()
 		self.keybindFrame.label:SetText(priority.."|cffffffff"..L["Bind"].."|r")
 	end
 
-	--set a repeating timer when the BUTTON is shown to enable or disable Keyboard input on mouseover.
+	--set a repeating timer when the Button is shown to enable or disable Keyboard input on mouseover.
 	self.keybindFrame.keybindUpdateTimer = self:ScheduleRepeatingTimer(function()
 		if self.keybindFrame:IsMouseOver() then
 			self.keybindFrame:EnableKeyboard(true)
@@ -255,13 +255,13 @@ function BUTTON:KeybindOverlay_OnShow()
 end
 
 --- OnHide Event handler
-function BUTTON:KeybindOverlay_OnHide()
+function Button:KeybindOverlay_OnHide()
 	--Cancel the repeating time when hiding the bar
 	self:CancelTimer(self.keybindFrame.keybindUpdateTimer)
 end
 
 --- OnEnter Event handler
-function BUTTON:KeybindOverlay_OnEnter()
+function Button:KeybindOverlay_OnEnter()
 	local name
 
 	---TODO:we should definitely added name strings for pets/companions as well. This was just to get it going
@@ -294,14 +294,14 @@ function BUTTON:KeybindOverlay_OnEnter()
 end
 
 --- OnLeave Event handler
-function BUTTON:KeybindOverlay_OnLeave()
+function Button:KeybindOverlay_OnLeave()
 	self.keybindFrame.select:Hide()
 	GameTooltip:Hide()
 end
 
 --- OnClick Event handler
 --- @param mousebutton string @The button that was clicked
-function BUTTON:KeybindOverlay_OnClick(mousebutton)
+function Button:KeybindOverlay_OnClick(mousebutton)
 	if mousebutton == "LeftButton" then
 		if self.keys.hotKeyLock then
 			self.keys.hotKeyLock = false
@@ -340,7 +340,7 @@ end
 
 --- OnKeyDown Event handler
 --- @param key string @The key that was pressed
-function BUTTON:KeybindOverlay_OnKeyDown(key)
+function Button:KeybindOverlay_OnKeyDown(key)
 	if key:find("ALT") or key:find("SHIFT") or key:find("CTRL") or key:find("PRINTSCREEN") then
 		return
 	end
@@ -356,7 +356,7 @@ end
 
 --- OnMouseWheel Event handler
 --- @param delta number @direction mouse wheel moved
-function BUTTON:KeybindOverlay_OnMouseWheel(delta)
+function Button:KeybindOverlay_OnMouseWheel(delta)
 	local modifier = GetModifier()
 	local key
 	local action

--- a/Objects/CastButton.lua
+++ b/Objects/CastButton.lua
@@ -6,15 +6,15 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class CASTBTN : STATUSBTN @define class CASTBTN inherits from class STATUSBTN
-local CASTBTN = setmetatable({}, { __index = Neuron.STATUSBTN })
-Neuron.CASTBTN = CASTBTN
+---@class CastButton : StatusButton @define class CastButton inherits from class StatusButton
+local CastButton = setmetatable({}, { __index = Neuron.StatusButton })
+Neuron.CastButton = CastButton
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
 local castWatch = {}
 
-CASTBTN.sbStrings = {
+CastButton.sbStrings = {
 	[1] = { L["None"], function(self) return "" end },
 	[2] = { L["Spell"], function(self) if castWatch[self:GetUnit()] then return castWatch[self:GetUnit()].spell end end },
 	[3] = { L["Timer"], function(self) if castWatch[self:GetUnit()] then return castWatch[self:GetUnit()].timer end end },
@@ -25,20 +25,20 @@ local CASTING_BAR_ALPHA_STEP = 0.05
 local CASTING_BAR_FLASH_STEP = 0.2
 local CASTING_BAR_HOLD_TIME = 1
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return CASTBTN @ A newly created STATUSBTN object
-function CASTBTN.new(bar, buttonID, defaults)
+---@return CastButton @ A newly created StatusButton object
+function CastButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.STATUSBTN.new(bar, buttonID, defaults, CASTBTN, "CastBar", "Cast Button")
+	local newButton = Neuron.StatusButton.new(bar, buttonID, defaults, CastButton, "CastBar", "Cast Button")
 
 	return newButton
 end
 
 
-function CASTBTN:InitializeButton()
+function CastButton:InitializeButton()
 	self:RegisterEvent("UNIT_SPELLCAST_START", "OnEvent")
 	self:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED", "OnEvent")
 	self:RegisterEvent("UNIT_SPELLCAST_FAILED", "OnEvent")
@@ -63,7 +63,7 @@ function CASTBTN:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function CASTBTN:OnEvent(event,...)
+function CastButton:OnEvent(event,...)
 	local unit = select(1, ...)
 	local eventCastID = select(2,...) --return payload is "unitTarget", "castGUID", spellID
 
@@ -248,7 +248,7 @@ function CASTBTN:OnEvent(event,...)
 	end
 end
 
-function CASTBTN:OnUpdate(elapsed)
+function CastButton:OnUpdate(elapsed)
 	--bail out if these values don't exist. Otherwise we will error later on
 	if not self.value and not self.maxValue then
 		self:Reset()
@@ -327,7 +327,7 @@ function CASTBTN:OnUpdate(elapsed)
 	end
 end
 
-function CASTBTN:FinishCast()
+function CastButton:FinishCast()
 	self.StatusBar.Spark:Hide()
 	self.StatusBar.BarFlash:SetAlpha(1.0)
 	self.StatusBar.BarFlash:Show()
@@ -337,7 +337,7 @@ function CASTBTN:FinishCast()
 	self.channeling = nil
 end
 
-function CASTBTN:Reset()
+function CastButton:Reset()
 	self.fadeout = true
 	self.casting = nil
 	self.channeling = nil
@@ -352,7 +352,7 @@ end
 -------------------Sets and Gets---------------------
 -----------------------------------------------------
 
-function CASTBTN:SetUnit(unit)
+function CastButton:SetUnit(unit)
 	--possible types are "player", "pet", "target", "targettarget", "focus", "mouseover", "party1", "party2", "party3", or "party4"
 	if unit then
 		self.config.unit = unit
@@ -361,14 +361,14 @@ function CASTBTN:SetUnit(unit)
 	end
 end
 
-function CASTBTN:GetUnit()
+function CastButton:GetUnit()
 	return self.config.unit
 end
 
-function CASTBTN:SetShowIcon(show)
+function CastButton:SetShowIcon(show)
 	self.config.showIcon = show
 end
 
-function CASTBTN:GetShowIcon()
+function CastButton:GetShowIcon()
 	return self.config.showIcon
 end

--- a/Objects/ExitButton.lua
+++ b/Objects/ExitButton.lua
@@ -6,21 +6,21 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class EXITBTN : BUTTON @define class EXITBTN inherits from class BUTTON
-local EXITBTN = setmetatable({}, { __index = Neuron.BUTTON })
-Neuron.EXITBTN = EXITBTN
+---@class ExitButton : Button @define class ExitButton inherits from class Button
+local ExitButton = setmetatable({}, { __index = Neuron.Button })
+Neuron.ExitButton = ExitButton
 
 
 ----------------------------------------------------------
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return EXITBTN @ A newly created EXITBTN object
-function EXITBTN.new(bar, buttonID, defaults)
+---@return ExitButton @ A newly created ExitButton object
+function ExitButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.BUTTON.new(bar, buttonID, EXITBTN, "ExitBar", "VehicleExitButton", "NeuronActionButtonTemplate")
+	local newButton = Neuron.Button.new(bar, buttonID, ExitButton, "ExitBar", "VehicleExitButton", "NeuronActionButtonTemplate")
 
 	if defaults then
 		newButton:SetDefaults(defaults)
@@ -31,7 +31,7 @@ end
 
 ----------------------------------------------------------
 
-function EXITBTN:InitializeButton()
+function ExitButton:InitializeButton()
 	self:RegisterEvent("UPDATE_BONUS_ACTIONBAR", "OnEvent")
 	self:RegisterEvent("UPDATE_VEHICLE_ACTIONBAR", "OnEvent")
 	self:RegisterEvent("UPDATE_OVERRIDE_ACTIONBAR", "OnEvent");
@@ -47,13 +47,13 @@ function EXITBTN:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function EXITBTN:InitializeButtonSettings()
+function ExitButton:InitializeButtonSettings()
 	self.bar:SetShowGrid(false)
 	self:SetFrameStrata(Neuron.STRATAS[self.bar:GetStrata()-1])
 	self:SetSkinned()
 end
 
-function EXITBTN:OnEvent(event, ...)
+function ExitButton:OnEvent(event, ...)
 	--reset button back to normal in the case of setting a tint on prior taxi trip
 	self.Icon:SetDesaturated(false)
 	if not InCombatLockdown() then
@@ -64,7 +64,7 @@ function EXITBTN:OnEvent(event, ...)
 	self:UpdateVisibility()
 end
 
-function EXITBTN:OnClick()
+function ExitButton:OnClick()
 	if UnitOnTaxi("player") then
 		TaxiRequestEarlyLanding()
 		--desaturate the button if early landing is requested and disable it
@@ -80,26 +80,26 @@ end
 --------------------- Overrides ---------------------
 -----------------------------------------------------
 
---overwrite function in parent class BUTTON
-function EXITBTN:UpdateVisibility()
+--overwrite function in parent class Button
+function ExitButton:UpdateVisibility()
 	if CanExitVehicle() or UnitOnTaxi("player") then --set alpha instead of :Show or :Hide, to avoid taint and to allow the button to appear in combat
 		self.isShown = true
 	else
 		self.isShown = false
 	end
 
-	Neuron.BUTTON.UpdateVisibility(self) --call parent function
+	Neuron.Button.UpdateVisibility(self) --call parent function
 end
 
---overwrite function in parent class BUTTON
-function EXITBTN:UpdateIcon()
+--overwrite function in parent class Button
+function ExitButton:UpdateIcon()
 	self.Icon:SetTexture("Interface\\AddOns\\Neuron\\Images\\new_vehicle_exit")
 	--make sure our button gets the correct Normal texture if we're not using a Masque skin
 	self:UpdateNormalTexture()
 end
 
---overwrite function in parent class BUTTON
-function EXITBTN:UpdateTooltip()
+--overwrite function in parent class Button
+function ExitButton:UpdateTooltip()
 	if not self.isShown then
 		return
 	end

--- a/Objects/ExpButton.lua
+++ b/Objects/ExpButton.lua
@@ -6,13 +6,13 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class XPBTN: STATUSBTN @define class XPBTN inherits from class STATUSBTN
-local XPBTN = setmetatable({}, { __index = Neuron.STATUSBTN })
-Neuron.XPBTN = XPBTN
+---@class ExpButton: StatusButton @define class ExpButton inherits from class StatusButton
+local ExpButton = setmetatable({}, { __index = Neuron.StatusButton })
+Neuron.ExpButton = ExpButton
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
-XPBTN.sbStrings = {
+ExpButton.sbStrings = {
 	[1] = { L["None"], function(self) return "" end },
 	[2] = { L["Current/Next"], function(self) if self.current and self.next then return BreakUpLargeNumbers(self.current).." / "..BreakUpLargeNumbers(self.next) end end },
 	[3] = { L["Rested Levels"], function(self) if self.rested then return string.format("%.2f", tostring(self.rested)).." "..L["Levels"] end end },
@@ -22,19 +22,19 @@ XPBTN.sbStrings = {
 }
 
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return XPBTN @ A newly created STATUSBTN object
-function XPBTN.new(bar, buttonID, defaults)
+---@return ExpButton @ A newly created StatusButton object
+function ExpButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.STATUSBTN.new(bar, buttonID, defaults, XPBTN, "XPBar", "XP Button")
+	local newButton = Neuron.StatusButton.new(bar, buttonID, defaults, ExpButton, "XPBar", "XP Button")
 
 	return newButton
 end
 
-function XPBTN:InitializeButton()
+function ExpButton:InitializeButton()
 	self:SetAttribute("hasaction", true)
 
 	self:RegisterForClicks("RightButtonUp")
@@ -61,7 +61,7 @@ function XPBTN:InitializeButton()
 end
 
 ---TODO: right now we are using DB.statusbtn to assign settings ot the status buttons, but I think our indexes are bar specific
-function XPBTN:UpdateData() --handles updating all the strings for the play XP watch bar
+function ExpButton:UpdateData() --handles updating all the strings for the play XP watch bar
 	--player xp option
 	if self:GetXPType() == "player_xp" then
 		self.current, self.next, self.rested = UnitXP("player"), UnitXPMax("player"), GetXPExhaustion()
@@ -131,7 +131,7 @@ function XPBTN:UpdateData() --handles updating all the strings for the play XP w
 	end
 end
 
-function XPBTN:OnEvent(event)
+function ExpButton:OnEvent(event)
 	self:UpdateData()
 
 	if self:GetXPType() == "player_xp" and (event=="PLAYER_XP_UPDATE" or event =="PLAYER_ENTERING_WORLD" or event=="UPDATE_EXHAUSTION" or event =="changed_curXPType") then
@@ -162,7 +162,7 @@ function XPBTN:OnEvent(event)
 	self.StatusBar.MouseoverText:SetText(self:mFunc())
 end
 
-function XPBTN:InitializeDropDown() -- initialize the dropdown menu for chosing to watch either XP, azerite XP, or Honor Points
+function ExpButton:InitializeDropDown() -- initialize the dropdown menu for chosing to watch either XP, azerite XP, or Honor Points
 	--this is the frame that will hold our dropdown menu
 	local menuFrame
 	if not NeuronXPDropdownMenu then --try to avoid re-creating this over again if we don't have to
@@ -251,7 +251,7 @@ function XPBTN:InitializeDropDown() -- initialize the dropdown menu for chosing 
 	EasyMenu(menu, menuFrame, "cursor", 0 , 0, "MENU", 1)
 end
 
-function XPBTN:OnClick(mousebutton)
+function ExpButton:OnClick(mousebutton)
 	if (mousebutton == "RightButton") then
 		self:InitializeDropDown()
 	end
@@ -261,11 +261,11 @@ end
 -------------------Sets and Gets---------------------
 -----------------------------------------------------
 
-function XPBTN:SetXPType(newXPType)
+function ExpButton:SetXPType(newXPType)
 	self.config.curXPType = newXPType
 	self:OnEvent("changed_curXPType")
 end
 
-function XPBTN:GetXPType()
+function ExpButton:GetXPType()
 	return self.config.curXPType
 end

--- a/Objects/ExtraButton.lua
+++ b/Objects/ExtraButton.lua
@@ -6,20 +6,20 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class EXTRABTN : BUTTON @define class EXTRABTN inherits from class BUTTON
-local EXTRABTN = setmetatable({}, { __index = Neuron.BUTTON })
-Neuron.EXTRABTN = EXTRABTN
+---@class ExtraButton : Button @define class ExtraButton inherits from class Button
+local ExtraButton = setmetatable({}, { __index = Neuron.Button })
+Neuron.ExtraButton = ExtraButton
 
 ----------------------------------------------------------
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return EXTRABTN @ A newly created EXTRABTN object
-function EXTRABTN.new(bar, buttonID, defaults)
+---@return ExtraButton @ A newly created ExtraButton object
+function ExtraButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.BUTTON.new(bar, buttonID, EXTRABTN, "ExtraBar", "ExtraActionButton", "NeuronActionButtonTemplate")
+	local newButton = Neuron.Button.new(bar, buttonID, ExtraButton, "ExtraBar", "ExtraActionButton", "NeuronActionButtonTemplate")
 
 	if defaults then
 		newButton:SetDefaults(defaults)
@@ -32,7 +32,7 @@ end
 
 ----------------------------------------------------------
 
-function EXTRABTN:InitializeButton()
+function ExtraButton:InitializeButton()
 	self:RegisterEvent("UPDATE_EXTRA_ACTIONBAR", "OnEvent")
 	self:RegisterEvent("ZONE_CHANGED", "OnEvent")
 	self:RegisterEvent("SPELLS_CHANGED", "OnEvent")
@@ -60,13 +60,13 @@ function EXTRABTN:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function EXTRABTN:InitializeButtonSettings()
+function ExtraButton:InitializeButtonSettings()
 	self.bar:SetShowGrid(false)
 	self:SetFrameStrata(Neuron.STRATAS[self.bar:GetStrata()-1])
 	self:SetSkinned()
 end
 
-function EXTRABTN:OnEvent(event, ...)
+function ExtraButton:OnEvent(event, ...)
 	self:UpdateData()
 	if event == "PLAYER_ENTERING_WORLD" then
 		self:KeybindOverlay_ApplyBindings()
@@ -79,8 +79,8 @@ end
 --------------------- Overrides ---------------------
 -----------------------------------------------------
 
---overwrite function in parent class BUTTON
-function EXTRABTN:UpdateData()
+--overwrite function in parent class Button
+function ExtraButton:UpdateData()
 	--get specific extrabutton actionID. Try to query it long form, but if it can't will fall back to 169 (as is the 7.0+ default)
 	if HasExtraActionBar() then
 		--default to 169 as is the most of then the case as of 8.1
@@ -116,18 +116,18 @@ function EXTRABTN:UpdateData()
 	self:UpdateCount()
 end
 
---overwrite function in parent class BUTTON
-function EXTRABTN:UpdateVisibility()
+--overwrite function in parent class Button
+function ExtraButton:UpdateVisibility()
 	if HasExtraActionBar() then --set alpha instead of :Show or :Hide, to avoid taint and to allow the button to appear in combat
 		self.isShown = true
 	else
 		self.isShown = false
 	end
-	Neuron.BUTTON.UpdateVisibility(self) --call parent function
+	Neuron.Button.UpdateVisibility(self) --call parent function
 end
 
---overwrite function in parent class BUTTON
-function EXTRABTN:UpdateIcon()
+--overwrite function in parent class Button
+function ExtraButton:UpdateIcon()
 	local spellTexture = GetSpellTexture(self.spellID)
 	self.Icon:SetTexture(spellTexture)
 
@@ -143,8 +143,8 @@ function EXTRABTN:UpdateIcon()
 	self:UpdateNormalTexture()
 end
 
---overwrite function in parent class BUTTON
-function EXTRABTN:UpdateTooltip()
+--overwrite function in parent class Button
+function ExtraButton:UpdateTooltip()
 	if not self.isShown then
 		return
 	end

--- a/Objects/MenuButton.lua
+++ b/Objects/MenuButton.lua
@@ -8,12 +8,12 @@ local Neuron = addonTable.Neuron
 local Array = addonTable.utilities.Array
 
 
----@class MENUBTN : BUTTON @define class MENUBTN inherits from class BUTTON
-local MENUBTN = setmetatable({}, {__index = Neuron.BUTTON})
-Neuron.MENUBTN = MENUBTN
+---@class MenuButton : Button @define class MenuButton inherits from class Button
+local MenuButton = setmetatable({}, {__index = Neuron.Button})
+Neuron.MenuButton = MenuButton
 
 local blizzMenuButtons = not Neuron.isWoWRetail
-	and Array.initialize(#MICRO_BUTTONS, function(i) return _G[MICRO_BUTTONS[i]] end)
+	and Array.initialize(#MICRO_ButtonS, function(i) return _G[MICRO_ButtonS[i]] end)
 	or {
 		CharacterMicroButton,
 		SpellbookMicroButton,
@@ -30,14 +30,14 @@ local blizzMenuButtons = not Neuron.isWoWRetail
 
 ---------------------------------------------------------
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return MENUBTN @ A newly created MENUBTN object
-function MENUBTN.new(bar, buttonID, defaults)
+---@return MenuButton @ A newly created MenuButton object
+function MenuButton.new(bar, buttonID, defaults)
 	---call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.BUTTON.new(bar, buttonID, MENUBTN, "MenuBar", "MenuButton", "NeuronAnchorButtonTemplate")
+	local newButton = Neuron.Button.new(bar, buttonID, MenuButton, "MenuBar", "MenuButton", "NeuronAnchorButtonTemplate")
 
 	if defaults then
 		newButton:SetDefaults(defaults)
@@ -48,14 +48,14 @@ end
 
 ---------------------------------------------------------
 
-function MENUBTN:InitializeButton()
+function MenuButton:InitializeButton()
 	if Neuron.isWoWRetail then
 		if not self:IsEventRegistered("PET_BATTLE_CLOSE") then --only run this code on the first InitializeButton, not the reloads after pet battles and such
 			self:RegisterEvent("PET_BATTLE_CLOSE")
 		end
 
 		if not Neuron:IsHooked("MoveMicroButtons") then --we need to intercept MoveMicroButtons for during pet battles
-			Neuron:RawHook("MoveMicroButtons", function(...) MENUBTN.ModifiedMoveMicroButtons(...) end, true)
+			Neuron:RawHook("MoveMicroButtons", function(...) MenuButton.ModifiedMoveMicroButtons(...) end, true)
 		end
 	end
 
@@ -77,20 +77,20 @@ function MENUBTN:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function MENUBTN:InitializeButtonSettings()
+function MenuButton:InitializeButtonSettings()
 	self:SetFrameStrata(Neuron.STRATAS[self.bar:GetStrata()-1])
 	self:SetScale(self.bar:GetBarScale())
 	self.isShown = true
 end
 
-function MENUBTN:PET_BATTLE_CLOSE()
+function MenuButton:PET_BATTLE_CLOSE()
 	---we have to reload InitializeButton to put the buttons back at the end of the pet battle
 	self:InitializeButton()
 end
 
 ---this overwrites the default MoveMicroButtons and basically just extends it to reposition all the other buttons as well, not just the 1st and 6th.
 ---This is necessary for petbattles, otherwise there's no menubar
-function MENUBTN.ModifiedMoveMicroButtons(anchor, anchorTo, relAnchor, x, y, isStacked)
+function MenuButton.ModifiedMoveMicroButtons(anchor, anchorTo, relAnchor, x, y, isStacked)
 	blizzMenuButtons[1]:ClearAllPoints();
 	blizzMenuButtons[1]:SetPoint(anchor, anchorTo, relAnchor, x-3, y-1);
 
@@ -111,27 +111,27 @@ end
 --------------------- Overrides ---------------------
 -----------------------------------------------------
 
---overwrite function in parent class BUTTON
-function MENUBTN:UpdateStatus()
+--overwrite function in parent class Button
+function MenuButton:UpdateStatus()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function MENUBTN:UpdateIcon()
+--overwrite function in parent class Button
+function MenuButton:UpdateIcon()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function MENUBTN:UpdateUsable()
+--overwrite function in parent class Button
+function MenuButton:UpdateUsable()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function MENUBTN:UpdateCount()
+--overwrite function in parent class Button
+function MenuButton:UpdateCount()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function MENUBTN:UpdateCooldown()
+--overwrite function in parent class Button
+function MenuButton:UpdateCooldown()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function MENUBTN:UpdateTooltip()
+--overwrite function in parent class Button
+function MenuButton:UpdateTooltip()
 	-- empty --
 end

--- a/Objects/MirrorButton.lua
+++ b/Objects/MirrorButton.lua
@@ -6,15 +6,15 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class MIRRORBTN : STATUSBTN @define class REPBTN inherits from class STATUSBTN
-local MIRRORBTN = setmetatable({}, { __index = Neuron.STATUSBTN })
-Neuron.MIRRORBTN = MIRRORBTN
+---@class MirrorButton : StatusButton @define class RepButton inherits from class StatusButton
+local MirrorButton = setmetatable({}, { __index = Neuron.StatusButton })
+Neuron.MirrorButton = MirrorButton
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
 local mirrorWatch, mirrorBars = {}, {}
 
-MIRRORBTN.sbStrings = {
+MirrorButton.sbStrings = {
 	[1] = { L["None"], function(self) return "" end },
 	[2] = { L["Type"], function(self) if mirrorWatch[self.mirror] then return mirrorWatch[self.mirror].label end end },
 	[3] = { L["Timer"], function(self) if mirrorWatch[self.mirror] then return mirrorWatch[self.mirror].timer end end },
@@ -38,19 +38,19 @@ MirrorTimerColors["FEIGNDEATH"] = {
 };
 
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return MIRRORBTN @ A newly created STATUSBTN object
-function MIRRORBTN.new(bar, buttonID, defaults)
+---@return MirrorButton @ A newly created StatusButton object
+function MirrorButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.STATUSBTN.new(bar, buttonID, defaults, MIRRORBTN, "MirrorBar", "Mirror Button")
+	local newButton = Neuron.StatusButton.new(bar, buttonID, defaults, MirrorButton, "MirrorBar", "Mirror Button")
 
 	return newButton
 end
 
-function MIRRORBTN:InitializeButton()
+function MirrorButton:InitializeButton()
 	self:RegisterEvent("MIRROR_TIMER_START", "OnEvent")
 	self:RegisterEvent("MIRROR_TIMER_STOP", "OnEvent")
 	self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnEvent")
@@ -64,7 +64,7 @@ function MIRRORBTN:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function MIRRORBTN:OnEvent(event, ...)
+function MirrorButton:OnEvent(event, ...)
 	if event == "MIRROR_TIMER_START" then
 		self:Start(...)
 
@@ -82,7 +82,7 @@ function MIRRORBTN:OnEvent(event, ...)
 	end
 end
 
-function MIRRORBTN:Start(type, value, maxvalue, scale, paused, label)
+function MirrorButton:Start(type, value, maxvalue, scale, paused, label)
 
 	if not mirrorWatch[type] then
 		mirrorWatch[type] = { active = false, mbar = nil, label = "", timer = "" }
@@ -112,7 +112,7 @@ function MIRRORBTN:Start(type, value, maxvalue, scale, paused, label)
 	end
 end
 
-function MIRRORBTN:Stop(type)
+function MirrorButton:Stop(type)
 	if mirrorWatch[type] and mirrorWatch[type].active then
 
 		local mbar = mirrorWatch[type].mbar
@@ -127,7 +127,7 @@ function MIRRORBTN:Stop(type)
 	end
 end
 
-function MIRRORBTN:OnUpdate()
+function MirrorButton:OnUpdate()
 	if self.mirror then
 		self.value = GetMirrorTimerProgress(self.mirror)/1000
 

--- a/Objects/PetButton.lua
+++ b/Objects/PetButton.lua
@@ -6,24 +6,24 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class PETBTN : BUTTON @define class PETBTN inherits from class BUTTON
-local PETBTN = setmetatable({}, { __index = Neuron.BUTTON })
-Neuron.PETBTN = PETBTN
+---@class PetButton : Button @define class PetButton inherits from class Button
+local PetButton = setmetatable({}, { __index = Neuron.Button })
+Neuron.PetButton = PetButton
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
-LibStub("AceEvent-3.0"):Embed(PETBTN)
-LibStub("AceTimer-3.0"):Embed(PETBTN)
+LibStub("AceEvent-3.0"):Embed(PetButton)
+LibStub("AceTimer-3.0"):Embed(PetButton)
 
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return PETBTN @ A newly created PETBTN object
-function PETBTN.new(bar, buttonID, defaults)
+---@return PetButton @ A newly created PetButton object
+function PetButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.BUTTON.new(bar, buttonID, PETBTN, "PetBar", "PetButton", "NeuronActionButtonTemplate")
+	local newButton = Neuron.Button.new(bar, buttonID, PetButton, "PetBar", "PetButton", "NeuronActionButtonTemplate")
 
 	if defaults then
 		newButton:SetDefaults(defaults)
@@ -34,7 +34,7 @@ function PETBTN.new(bar, buttonID, defaults)
 	return newButton
 end
 
-function PETBTN:InitializeButton()
+function PetButton:InitializeButton()
 	self:RegisterEvent("PLAYER_ENTERING_WORLD")
 	self:RegisterEvent("UNIT_PET")
 	self:RegisterEvent("PET_BAR_UPDATE", "UpdateData")
@@ -72,7 +72,7 @@ function PETBTN:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function PETBTN:InitializeButtonSettings()
+function PetButton:InitializeButtonSettings()
 	self:SetFrameStrata(Neuron.STRATAS[self.bar:GetStrata()-1])
 	self:SetScale(self.bar:GetBarScale())
 
@@ -103,20 +103,20 @@ function PETBTN:InitializeButtonSettings()
 	self:SetSkinned()
 end
 
-function PETBTN:PLAYER_ENTERING_WORLD()
+function PetButton:PLAYER_ENTERING_WORLD()
 	self:UpdateAll()
 	self:KeybindOverlay_ApplyBindings()
 
 	self:ScheduleTimer(function() self:UpdateVisibility() end, 1)
 end
 
-function PETBTN:UNIT_PET(event, unit)
+function PetButton:UNIT_PET(event, unit)
 	if unit ==  "player" then
 		self:UpdateData()
 	end
 end
 
-function PETBTN:OnDragStart()
+function PetButton:OnDragStart()
 	if InCombatLockdown() then
 		return
 	end
@@ -147,7 +147,7 @@ function PETBTN:OnDragStart()
 end
 
 
-function PETBTN:OnReceiveDrag()
+function PetButton:OnReceiveDrag()
 	if InCombatLockdown() then
 		return
 	end
@@ -170,8 +170,8 @@ end
 --------------------- Overrides ---------------------
 -----------------------------------------------------
 
---overwrite function in parent class BUTTON
-function PETBTN:UpdateData()
+--overwrite function in parent class Button
+function PetButton:UpdateData()
 	if not self.actionID then
 		return
 	end
@@ -191,8 +191,8 @@ function PETBTN:UpdateData()
 	self:UpdateStatus()
 end
 
---overwrite function in parent class BUTTON
-function PETBTN:UpdateIcon()
+--overwrite function in parent class Button
+function PetButton:UpdateIcon()
 	if not self.actionID then
 		return
 	end
@@ -218,8 +218,8 @@ function PETBTN:UpdateIcon()
 	self:UpdateNormalTexture()
 end
 
---overwrite function in parent class BUTTON
-function PETBTN:UpdateStatus()
+--overwrite function in parent class Button
+function PetButton:UpdateStatus()
 	if not self.actionID then
 		return
 	end
@@ -261,16 +261,16 @@ function PETBTN:UpdateStatus()
 	self:UpdateUsable()
 end
 
---overwrite function in parent class BUTTON
-function PETBTN:UpdateCooldown()
+--overwrite function in parent class Button
+function PetButton:UpdateCooldown()
 	if self.actionID and GetPetActionInfo(self.actionID) then
 		local start, duration, enable, modrate = GetPetActionCooldown(self.actionID)
 		self:SetCooldownTimer(start, duration, enable, modrate, self.bar:GetShowCooldownText(), self.bar:GetCooldownColor1(), self.bar:GetCooldownColor2(), self.bar:GetShowCooldownAlpha())
 	end
 end
 
---overwrite function in parent class BUTTON
-function PETBTN:UpdateUsable()
+--overwrite function in parent class Button
+function PetButton:UpdateUsable()
 	if Neuron.buttonEditMode or Neuron.bindingMode then
 		self.Icon:SetVertexColor(0.2, 0.2, 0.2)
 	elseif self.actionID and GetPetActionSlotUsable(self.actionID) then
@@ -280,8 +280,8 @@ function PETBTN:UpdateUsable()
 	end
 end
 
---overwrite function in parent class BUTTON
-function PETBTN:UpdateTooltip()
+--overwrite function in parent class Button
+function PetButton:UpdateTooltip()
 	--if we are in combat and we don't have tooltips enable in-combat, don't go any further
 	if InCombatLockdown() and not self.bar:GetTooltipCombat() then
 		return
@@ -298,12 +298,12 @@ function PETBTN:UpdateTooltip()
 	end
 end
 
---overwrite function in parent class BUTTON
-function PETBTN:UpdateVisibility(show)
+--overwrite function in parent class Button
+function PetButton:UpdateVisibility(show)
 	if (self.bar:GetShowGrid() and IsPetActive()) or (self.actionID and GetPetActionInfo(self.actionID) and IsPetActive()) or show then
 		self.isShown = true
 	else
 		self.isShown = false
 	end
-	Neuron.BUTTON.UpdateVisibility(self) --call parent function
+	Neuron.Button.UpdateVisibility(self) --call parent function
 end

--- a/Objects/RepButton.lua
+++ b/Objects/RepButton.lua
@@ -6,15 +6,15 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class REPBTN : STATUSBTN @define class REPBTN inherits from class STATUSBTN
-local REPBTN = setmetatable({}, { __index = Neuron.STATUSBTN })
-Neuron.REPBTN = REPBTN
+---@class RepButton : StatusButton @define class RepButton inherits from class StatusButton
+local RepButton = setmetatable({}, { __index = Neuron.StatusButton })
+Neuron.RepButton = RepButton
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
 local RepWatch = {}
 
-REPBTN.sbStrings = {
+RepButton.sbStrings = {
 	[1] = { L["None"], function() return "" end },
 	[2] = { L["Faction"], function(self) if RepWatch[self.repID] then return RepWatch[self.repID].name end end }, --TODO:should probably do the same as above here, just in case people have more than 1 rep bar
 	[3] = { L["Current/Next"], function(self) if RepWatch[self.repID] then return RepWatch[self.repID].current end end },
@@ -24,19 +24,19 @@ REPBTN.sbStrings = {
 }
 
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return REPBTN @ A newly created STATUSBTN object
-function REPBTN.new(bar, buttonID, defaults)
+---@return RepButton @ A newly created StatusButton object
+function RepButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.STATUSBTN.new(bar, buttonID, defaults, REPBTN, "RepBar", "Rep Button")
+	local newButton = Neuron.StatusButton.new(bar, buttonID, defaults, RepButton, "RepBar", "Rep Button")
 
 	return newButton
 end
 
-function REPBTN:InitializeButton()
+function RepButton:InitializeButton()
 	self:SetAttribute("hasaction", true)
 
 	self:RegisterForClicks("RightButtonUp")
@@ -85,7 +85,7 @@ local function SetRepWatch(ID, name, standing, header, minrep, maxrep, value, co
 	return reptable
 end
 
-function REPBTN:UpdateData(repGainedString)
+function RepButton:UpdateData(repGainedString)
 	local BAR_REP_DATA = {
 		[0] = { l="Unknown", r=0.5, g=0.5, b=0.5, a=1.0 },
 		[1] = { l="Hated", r=0.6, g=0.1, b=0.1, a=1.0 },
@@ -182,7 +182,7 @@ function REPBTN:UpdateData(repGainedString)
 	end
 end
 
-function REPBTN:OnEvent(event,...)
+function RepButton:OnEvent(event,...)
 	self:UpdateData(...)
 
 	if RepWatch[self.repID] then
@@ -202,7 +202,7 @@ function REPBTN:OnEvent(event,...)
 end
 
 
-function REPBTN:InitializeDropDown() --Initialize the dropdown menu for choosing a rep
+function RepButton:InitializeDropDown() --Initialize the dropdown menu for choosing a rep
 	local repDataTable = {}
 
 	for k,v in pairs(RepWatch) do --insert all factions and percentages into "data"
@@ -345,7 +345,7 @@ function REPBTN:InitializeDropDown() --Initialize the dropdown menu for choosing
 end
 
 
-function REPBTN:OnClick(mousebutton)
+function RepButton:OnClick(mousebutton)
 	if mousebutton == "RightButton" then
 		self:InitializeDropDown()
 	end

--- a/Objects/StatusButton.lua
+++ b/Objects/StatusButton.lua
@@ -6,9 +6,9 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class STATUSBTN : BUTTON @define class STATUSBTN inherits from class BUTTON
-local STATUSBTN = setmetatable({}, { __index = Neuron.BUTTON })
-Neuron.STATUSBTN = STATUSBTN
+---@class StatusButton : Button @define class StatusButton inherits from class Button
+local StatusButton = setmetatable({}, { __index = Neuron.Button })
+Neuron.StatusButton = StatusButton
 
 local L = LibStub("AceLocale-3.0"):GetLocale("Neuron")
 
@@ -34,15 +34,15 @@ local BAR_ORIENTATIONS = {
 	[2] = "Vertical",
 }
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return STATUSBTN @ A newly created STATUSBTN object
-function STATUSBTN.new(bar, buttonID, defaults, barObj, barType, objType)
+---@return StatusButton @ A newly created StatusButton object
+function StatusButton.new(bar, buttonID, defaults, barObj, barType, objType)
 	--call the parent object constructor with the provided information specific to this button type
-	--local newButton = Neuron.BUTTON.new(bar, buttonID, STATUSBTN, "StatusBar", "StatusBar", "NeuronStatusBarTemplate")
-	local newButton = Neuron.BUTTON.new(bar, buttonID, barObj, barType, objType, "NeuronStatusBarTemplate")
+	--local newButton = Neuron.Button.new(bar, buttonID, StatusButton, "StatusBar", "StatusBar", "NeuronStatusBarTemplate")
+	local newButton = Neuron.Button.new(bar, buttonID, barObj, barType, objType, "NeuronStatusBarTemplate")
 
 	if defaults then
 		newButton:SetDefaults(defaults)
@@ -53,7 +53,7 @@ function STATUSBTN.new(bar, buttonID, defaults, barObj, barType, objType)
 	return newButton
 end
 
-function STATUSBTN:InitializeButtonSettings()
+function StatusButton:InitializeButtonSettings()
 	self:SetFrameStrata(Neuron.STRATAS[self.bar:GetStrata()-1])
 	self:SetScale(self.bar:GetBarScale())
 
@@ -119,7 +119,7 @@ function STATUSBTN:InitializeButtonSettings()
 	self:SetBorder()
 end
 
-function STATUSBTN:SetBorder()
+function StatusButton:SetBorder()
 	self.StatusBar.Border:SetBackdrop({
 		bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
 		edgeFile = BAR_BORDERS[self.config.border][2],
@@ -158,7 +158,7 @@ function STATUSBTN:SetBorder()
 	})
 end
 
-function STATUSBTN:OnEnter()
+function StatusButton:OnEnter()
 	if self.config.mIndex > 1 then
 		self.StatusBar.CenterText:Hide()
 		self.StatusBar.LeftText:Hide()
@@ -181,7 +181,7 @@ function STATUSBTN:OnEnter()
 	end
 end
 
-function STATUSBTN:OnLeave()
+function StatusButton:OnLeave()
 	if self.config.mIndex > 1 then
 		self.StatusBar.CenterText:Show()
 		self.StatusBar.LeftText:Show()
@@ -197,7 +197,7 @@ function STATUSBTN:OnLeave()
 	end
 end
 
-function STATUSBTN:UpdateWidth(command)
+function StatusButton:UpdateWidth(command)
 	local width = tonumber(command)
 	if width and width >= 10 then
 		self.config.width = width
@@ -208,7 +208,7 @@ function STATUSBTN:UpdateWidth(command)
 	end
 end
 
-function STATUSBTN:UpdateHeight(command)
+function StatusButton:UpdateHeight(command)
 	local height = tonumber(command)
 	if height and height >= 4 then
 		self.config.height = height
@@ -219,7 +219,7 @@ function STATUSBTN:UpdateHeight(command)
 	end
 end
 
-function STATUSBTN:UpdateBarFill(command)
+function StatusButton:UpdateBarFill(command)
 	local index = tonumber(command)
 	if index and BAR_TEXTURES[index] then
 		self.config.texture = index
@@ -227,7 +227,7 @@ function STATUSBTN:UpdateBarFill(command)
 	end
 end
 
-function STATUSBTN:UpdateBorder(command)
+function StatusButton:UpdateBorder(command)
 	local index = tonumber(command)
 	if index and BAR_BORDERS[index] then
 		self.config.border = index
@@ -235,7 +235,7 @@ function STATUSBTN:UpdateBorder(command)
 	end
 end
 
-function STATUSBTN:UpdateOrientation(command)
+function StatusButton:UpdateOrientation(command)
 	local index = tonumber(command)
 	if index then
 		--only update if we're changing, not staying the same
@@ -271,7 +271,7 @@ function STATUSBTN:UpdateOrientation(command)
 	end
 end
 
-function STATUSBTN:UpdateCenterText(command)
+function StatusButton:UpdateCenterText(command)
 	local index = tonumber(command)
 	if index then
 		self.config.cIndex = index
@@ -280,7 +280,7 @@ function STATUSBTN:UpdateCenterText(command)
 	end
 end
 
-function STATUSBTN:UpdateLeftText(command)
+function StatusButton:UpdateLeftText(command)
 	local index = tonumber(command)
 	if index then
 		self.config.lIndex = index
@@ -289,7 +289,7 @@ function STATUSBTN:UpdateLeftText(command)
 	end
 end
 
-function STATUSBTN:UpdateRightText(command)
+function StatusButton:UpdateRightText(command)
 	if not self.sbStrings then
 		return "---"
 	end
@@ -302,7 +302,7 @@ function STATUSBTN:UpdateRightText(command)
 	end
 end
 
-function STATUSBTN:UpdateMouseover(command)
+function StatusButton:UpdateMouseover(command)
 	if not self.sbStrings then
 		return "---"
 	end
@@ -320,16 +320,16 @@ end
 --------------------- Overrides ---------------------
 -----------------------------------------------------
 
---overwrite function in parent class BUTTON
-function STATUSBTN:UpdateVisibility()
+--overwrite function in parent class Button
+function StatusButton:UpdateVisibility()
 	if Neuron.barEditMode or Neuron.buttonEditMode then
 		self.StatusBar:Show()
 		self.StatusBar:SetAlpha(1)
 	end
 end
 
---overwrite function in parent class BUTTON
-function STATUSBTN:UpdateStatus()
+--overwrite function in parent class Button
+function StatusButton:UpdateStatus()
 	if Neuron.barEditMode or Neuron.buttonEditMode then
 		self.StatusBar.CenterText:SetText("")
 		self.StatusBar.LeftText:SetText(self.typeString)
@@ -343,8 +343,8 @@ function STATUSBTN:UpdateStatus()
 	end
 end
 
---overwrite function in parent class BUTTON
-function STATUSBTN:UpdateTooltip(command)
+--overwrite function in parent class Button
+function StatusButton:UpdateTooltip(command)
 	if not self.sbStrings then
 		return "---"
 	end
@@ -356,19 +356,19 @@ function STATUSBTN:UpdateTooltip(command)
 	end
 end
 
---overwrite function in parent class BUTTON
-function STATUSBTN:UpdateIcon()
+--overwrite function in parent class Button
+function StatusButton:UpdateIcon()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function STATUSBTN:UpdateUsable()
+--overwrite function in parent class Button
+function StatusButton:UpdateUsable()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function STATUSBTN:UpdateCount()
+--overwrite function in parent class Button
+function StatusButton:UpdateCount()
 	-- empty --
 end
---overwrite function in parent class BUTTON
-function STATUSBTN:UpdateCooldown()
+--overwrite function in parent class Button
+function StatusButton:UpdateCooldown()
 	-- empty --
 end

--- a/Objects/ZoneAbilityButton.lua
+++ b/Objects/ZoneAbilityButton.lua
@@ -6,20 +6,20 @@
 local _, addonTable = ...
 local Neuron = addonTable.Neuron
 
----@class ZONEABILITYBTN : BUTTON @define class ZONEABILITYBTN inherits from class BUTTON
-local ZONEABILITYBTN = setmetatable({}, {__index = Neuron.BUTTON}) --this is the metatable for our button object
-Neuron.ZONEABILITYBTN = ZONEABILITYBTN
+---@class ZoneAbilityButton : Button @define class ZoneAbilityButton inherits from class Button
+local ZoneAbilityButton = setmetatable({}, {__index = Neuron.Button}) --this is the metatable for our button object
+Neuron.ZoneAbilityButton = ZoneAbilityButton
 
 ----------------------------------------------------------
 
----Constructor: Create a new Neuron BUTTON object (this is the base object for all Neuron button types)
----@param bar BAR @Bar Object this button will be a child of
+---Constructor: Create a new Neuron Button object (this is the base object for all Neuron button types)
+---@param bar Bar @Bar Object this button will be a child of
 ---@param buttonID number @Button ID that this button will be assigned
 ---@param defaults table @Default options table to be loaded onto the given button
----@return ZONEABILITYBTN @ A newly created ZONEABILITYBTN object
-function ZONEABILITYBTN.new(bar, buttonID, defaults)
+---@return ZoneAbilityButton @ A newly created ZoneAbilityButton object
+function ZoneAbilityButton.new(bar, buttonID, defaults)
 	--call the parent object constructor with the provided information specific to this button type
-	local newButton = Neuron.BUTTON.new(bar, buttonID, ZONEABILITYBTN, "ZoneAbilityBar", "ZoneActionButton", "NeuronActionButtonTemplate")
+	local newButton = Neuron.Button.new(bar, buttonID, ZoneAbilityButton, "ZoneAbilityBar", "ZoneActionButton", "NeuronActionButtonTemplate")
 
 	newButton.abilityIndex = buttonID
 
@@ -33,7 +33,7 @@ function ZONEABILITYBTN.new(bar, buttonID, defaults)
 end
 
 ----------------------------------------------------------
-function ZONEABILITYBTN:InitializeButton()
+function ZoneAbilityButton:InitializeButton()
 	self:RegisterUnitEvent("UNIT_AURA", "player")
 	self:RegisterEvent("SPELLS_CHANGED", "OnEvent")
 	self:RegisterEvent("ZONE_CHANGED", "OnEvent")
@@ -64,13 +64,13 @@ function ZONEABILITYBTN:InitializeButton()
 	self:InitializeButtonSettings()
 end
 
-function ZONEABILITYBTN:InitializeButtonSettings()
+function ZoneAbilityButton:InitializeButtonSettings()
 	self.bar:SetShowGrid(false)
 	self:SetFrameStrata(Neuron.STRATAS[self.bar:GetStrata()-1])
 	self:SetSkinned()
 end
 
-function ZONEABILITYBTN:OnEvent(event, ...)
+function ZoneAbilityButton:OnEvent(event, ...)
 	self:UpdateData();
 	if event == "PLAYER_ENTERING_WORLD" then
 		self:KeybindOverlay_ApplyBindings()
@@ -83,8 +83,8 @@ end
 --------------------- Overrides ---------------------
 -----------------------------------------------------
 
---overwrite function in parent class BUTTON
-function ZONEABILITYBTN:UpdateData()
+--overwrite function in parent class Button
+function ZoneAbilityButton:UpdateData()
 	--get table with zone ability info. The table has 5 values, "zoneAbilityID", "uiPriority", "spellID", "textureKit", and "tutorialText"
 	local zoneAbilityTable = C_ZoneAbility.GetActiveAbilities()
 
@@ -119,19 +119,19 @@ function ZONEABILITYBTN:UpdateData()
 	self:UpdateCount()
 end
 
---overwrite function in parent class BUTTON
-function ZONEABILITYBTN:UpdateVisibility()
+--overwrite function in parent class Button
+function ZoneAbilityButton:UpdateVisibility()
 	if self.spellID then
 		self.isShown = true
 	else
 		self.isShown = false
 	end
 
-	Neuron.BUTTON.UpdateVisibility(self) --call parent function
+	Neuron.Button.UpdateVisibility(self) --call parent function
 end
 
---overwrite function in parent class BUTTON
-function ZONEABILITYBTN:UpdateIcon()
+--overwrite function in parent class Button
+function ZoneAbilityButton:UpdateIcon()
 	local spellTexture = GetSpellTexture(self.spellID)
 	self.Icon:SetTexture(spellTexture);
 
@@ -152,8 +152,8 @@ function ZONEABILITYBTN:UpdateIcon()
 	self:UpdateNormalTexture()
 end
 
---overwrite function in parent class BUTTON
-function ZONEABILITYBTN:UpdateTooltip()
+--overwrite function in parent class Button
+function ZoneAbilityButton:UpdateTooltip()
 	if not self.isShown then
 		return
 	end


### PR DESCRIPTION
This is a part of my ever-continued attempts to bring some consistency to the formatting of this code. We've long dealt with ALL CAPS for the object names used by Neuron, and I figured it was time to modernize our code with a conversion to PascalCase.